### PR TITLE
Add Docker development configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Version control
+.git
+.gitignore
+
+# Python artifacts
+__pycache__
+*.pyc
+*.pyo
+*.egg-info
+dist/
+build/
+.eggs/
+
+# Virtual environments
+.venv
+venv
+env
+
+# IDE and editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Test and coverage artifacts
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Scratch and temporary files
+scratch/
+*.tmp

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,30 @@
+# Dockerfile.dev - E.C.H.O. Simulation Framework Development Container (x86/x64)
+#
+# Python environment with all three simulation layers installed, plus C toolchain
+# for HAL header development (Phase 2-3).
+#
+# Usage:
+#   docker build -f Dockerfile.dev -t echo-dev .
+#   docker run --rm -it echo-dev
+#   docker run --rm echo-dev pytest tests/
+
+FROM python:3.12-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# C toolchain for HAL header development (Phase 2-3)
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy simulation framework source
+WORKDIR /opt/echo
+COPY . .
+
+# Install all layers + dev tools
+RUN pip install --no-cache-dir -e ".[all,dev]"
+
+# Run tests by default to verify the build
+CMD ["pytest", "tests/", "-v"]

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,0 +1,80 @@
+# Docker Development Guide
+
+## Overview
+
+The E.C.H.O. simulation framework provides a development container with Python and a C toolchain pre-installed. This supports:
+
+- **Python development**: all three simulation layers (Device, Network, Platform)
+- **C HAL development**: gcc and cmake for HAL header compilation and C mock implementations (Phase 2-3)
+- **Testing**: pytest with coverage support
+
+## Quick Start
+
+```bash
+# Build the development image
+docker build -f Dockerfile.dev -t echo-dev .
+
+# Run tests (default command)
+docker run --rm echo-dev
+
+# Interactive development shell
+docker run --rm -it echo-dev bash
+
+# Run tests with coverage
+docker run --rm echo-dev pytest tests/ --cov=simulation
+```
+
+## Available Dockerfiles
+
+| Dockerfile | Platform | Purpose |
+|------------|----------|---------|
+| `Dockerfile.dev` | x86/x64 | Development and testing — Python + C toolchain |
+
+> **Note**: Unlike service components (M.I.R.A.G.E., D.A.W.N., S.T.A.T.), the simulation framework does not have Jetson or Raspberry Pi Dockerfiles. It runs on the developer's machine, not on target hardware.
+
+## Development Workflow
+
+### Mount Source for Live Editing
+
+```bash
+docker run --rm -it -v "$(pwd)":/opt/echo echo-dev bash
+```
+
+Changes to source files on the host are immediately reflected inside the container.
+
+### Layer-Specific Installation
+
+If you only need a subset of layers:
+
+```bash
+# Inside the container
+pip install -e "."           # Device layer only (no external deps)
+pip install -e ".[layer1]"   # + Network layer
+pip install -e ".[all]"      # All layers
+```
+
+### C HAL Development
+
+The container includes `gcc`, `g++`, and `cmake` for C HAL header compilation:
+
+```bash
+# Inside the container
+cd /opt/echo
+mkdir -p build && cd build
+cmake ..
+make -j$(nproc)
+```
+
+## Non-Containerized Alternative
+
+For development without Docker, use a Python virtual environment:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate       # Linux/macOS
+# .venv\Scripts\activate        # Windows
+pip install -e ".[all,dev]"
+pytest tests/
+```
+
+See `docs/guide.md` for full installation instructions.


### PR DESCRIPTION
## Summary
Add Docker development container with Python 3.12 and C toolchain (gcc/cmake) for both Python mock development and future C HAL header work (Phase 2-3). Includes `.dockerignore` and `docs/DOCKER.md` with build, run, and development workflow instructions.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactoring

## Testing
- [ ] `docker build -f Dockerfile.dev .` succeeds
- [ ] Container can `import simulation` and run MockSensor
- [ ] Container has gcc/cmake available

## Checklist
- [x] Documentation updated (docs/DOCKER.md)
- [x] No breaking changes

**Stacked on**: PR #6 (docs-gap-fill)
Closes #4
Tracked by: malcolmhoward/the-oasis-project-meta-repo#38 (onboarding sequence)
Tracked by: malcolmhoward/the-oasis-project-meta-repo#23 (Docker standardization)

---
🤖 Generated with [Claude Code](https://claude.ai/code)