### PR TITLE
Add Device layer — hardware primitives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,208 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py.cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+#poetry.toml
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#   pdm recommends including project-wide configuration in pdm.toml, but excluding .pdm-python.
+#   https://pdm-project.org/en/latest/usage/project/#working-with-version-control
+#pdm.lock
+#pdm.toml
+.pdm-python
+.pdm-build/
+
+# pixi
+#   Similar to Pipfile.lock, it is generally recommended to include pixi.lock in version control.
+#pixi.lock
+#   Pixi creates a virtual environment in the .pixi directory, just like venv module creates one
+#   in the .venv directory. It is recommended not to include this directory in version control.
+.pixi
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.envrc
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+# Abstra
+# Abstra is an AI-powered process automation framework.
+# Ignore directories containing user credentials, local state, and settings.
+# Learn more at https://abstra.io/docs
+.abstra/
+
+# Visual Studio Code
+#  Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#  that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
+#  and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#  you could uncomment the following to ignore the entire vscode folder
+# .vscode/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# Cursor
+#  Cursor is an AI-powered code editor. `.cursorignore` specifies files/directories to
+#  exclude from AI features like autocomplete and code analysis. Recommended for sensitive data
+#  refer to https://docs.cursor.com/context/ignore-files
+.cursorignore
+.cursorindexingignore
+
+# Marimo
+marimo/_static/
+marimo/_lsp/
+__marimo__/
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,26 +71,69 @@ pytest tests/ --cov=simulation
 
 ## Working with This Codebase
 
+### HAL-First Development Pattern
+
+All mock classes implement interface contracts defined in the HAL (Hardware
+Abstraction Layer) at `simulation/hal/`. **The interface should be defined
+before its implementation.** Writing implementations first risks implicit
+contracts that are harder to maintain across languages — future C HAL headers
+(Phase 2) need to derive from the same interface definitions.
+
+```
+simulation/hal/device.py     ← defines SensorInterface, GPIOInterface, ...
+simulation/layer0/sensor.py  ← MockSensor(SensorInterface)
+simulation/layer0/gpio.py    ← MockGPIO(GPIOInterface)
+```
+
+This ensures:
+- The contract is explicit and reviewable before implementation details
+- Both Python mocks and future C HAL headers conform to the same interface
+- In git history, the HAL commit precedes the implementation commit
+
 ### Adding a New Mock Class
 
-1. Create `simulation/layer<N>/<module>.py` in the appropriate layer
-2. Add the class to `simulation/layer<N>/__init__.py`
-3. If Layer 0: add convenience import to `simulation/__init__.py` and `__all__`
-4. Add tests in `tests/test_layer<N>.py`
-5. Verify the new class has no imports above its layer's dependency tier
+1. **Define the interface** in `simulation/hal/<layer>.py` as an ABC (Abstract
+   Base Class) with `@abstractmethod` for each public method
+2. **Commit the interface** before writing the implementation
+3. Create the mock in `simulation/layer<N>/<module>.py`, inheriting from the
+   HAL ABC
+4. Add the class to `simulation/layer<N>/__init__.py`
+5. If Layer 0: add convenience import to `simulation/__init__.py` and `__all__`
+6. Add tests in `tests/test_layer<N>.py`
+7. Verify the new class has no imports above its layer's dependency tier
 
 ### Layer Dependency Rules
 
-- Layer 0 modules must NOT import from `layer1` or `layer2`
-- Layer 1 modules must NOT import from `layer2`
-- Layer 2 may import from `layer0` and `layer1`
-- No layer may import from component repos (M.I.R.A.G.E., D.A.W.N., etc.)
+- `hal/` modules must NOT import from any `layer` module
+- Layer 0 modules may import from `hal/` only
+- Layer 1 modules may import from `hal/` and `layer0/`
+- Layer 2 modules may import from `hal/`, `layer0/`, and `layer1/`
+- No module may import from component repos (M.I.R.A.G.E., D.A.W.N., etc.)
 
 ### Mock Class Design Principles
 
+- Mock classes should **implement a HAL ABC** rather than defining interfaces implicitly — without an explicit interface, future implementations in other languages cannot verify conformance
 - Mock classes must be **interface-compatible** with the real drivers they replace
-- Support **selective injection**: applications can mix real and mock implementations
 - Each mock should be usable in isolation — no implicit global state
+
+### Injection Modes
+
+The simulation framework supports three injection phases (see ADR-0003 Amendment 4):
+
+| Phase | When | Description |
+|-------|------|-------------|
+| **Default** | Container/process start | All mocks active; no configuration needed |
+| **Explicit** | Container/process start | User declares which deps are real vs. mocked |
+| **Runtime** | After launch | Hardware/services appear or disappear; implementations swap transparently |
+
+Runtime injection enables **graceful degradation** — when real hardware disconnects,
+the framework falls back to mocks without crashing. When hardware reconnects, it
+promotes back to the real driver. This aligns with O.A.S.I.S.'s loose coupling and
+OCP component discovery architecture.
+
+Component code programs against the HAL interface. A **Provider** (not part of the
+HAL itself) manages which implementation is active and handles swapping. See
+ADR-0003 Amendment 4 for the full design.
 
 ## O.A.S.I.S. Component Interaction
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,344 @@
+# Contributing to O.A.S.I.S. Simulation Framework
+
+
+Thank you for your interest in contributing to O.A.S.I.S. Simulation Framework!
+
+This guide explains our contribution workflow, conventions, and review process.
+
+---
+
+## Before You Start
+
+### Understanding Our Workflow
+
+We use a **fork-first workflow**. This means:
+- You work on your own copy (fork) of the repository
+- Changes are proposed via Pull Requests from your fork
+- This keeps the main repository clean and secure
+
+### Why Fork-First?
+
+1. **Security**: Only maintainers have write access to the main repo
+2. **Experimentation**: You can freely experiment in your fork
+3. **Learning**: Great practice for contributing to any open source project
+4. **Backup**: Your fork serves as a backup of your work
+
+---
+
+## Fork-First Workflow
+
+### Step 1: Fork the Repository
+
+1. Click the "Fork" button on the repository page
+2. This creates your personal copy at `github.com/YOUR-USERNAME/the-oasis-project-simulation-repo`
+
+### Step 2: Clone Your Fork
+
+```bash
+# Clone your fork locally
+git clone https://github.com/YOUR-USERNAME/the-oasis-project-simulation-repo.git
+cd the-oasis-project-simulation-repo
+
+# Add the original repo as "upstream" for syncing
+git remote add upstream https://github.com/malcolmhoward/the-oasis-project-simulation-repo.git
+```
+
+### Step 3: Keep Your Fork Updated
+
+```bash
+# Fetch upstream changes
+git fetch upstream
+
+# Merge upstream main into your local main
+git checkout main
+git merge upstream/main
+
+# Push updates to your fork
+git push origin main
+```
+
+### Step 4: Create a Feature Branch
+
+**Never work directly on `main`**. Always create a branch:
+
+```bash
+git checkout -b type/description
+```
+
+---
+
+## Branch Naming Conventions
+
+Use descriptive branch names following this pattern:
+
+```
+type/short-description
+```
+
+### Branch Types
+
+| Type | Purpose | Example |
+|------|---------|---------|
+| `feat/` | New feature | `feat/user-authentication` |
+| `fix/` | Bug fix | `fix/login-validation` |
+| `docs/` | Documentation only | `docs/api-examples` |
+| `refactor/` | Code restructuring | `refactor/database-layer` |
+| `test/` | Adding/updating tests | `test/auth-unit-tests` |
+| `chore/` | Maintenance tasks | `chore/update-dependencies` |
+
+### Good Branch Names
+- `feat/add-dark-mode`
+- `fix/memory-leak-on-upload`
+- `docs/installation-guide`
+
+### Avoid
+- `my-changes` (not descriptive)
+- `fix` (too vague)
+- `john-branch` (personal names)
+
+---
+
+## Conventional Commits
+
+We follow [Conventional Commits](https://www.conventionalcommits.org/) for clear, consistent history.
+
+### Format
+
+```
+type(scope): description
+
+[optional body]
+
+[optional footer]
+```
+
+### Commit Types
+
+| Type | When to Use |
+|------|-------------|
+| `feat` | Adding new functionality |
+| `fix` | Fixing a bug |
+| `docs` | Documentation changes only |
+| `style` | Formatting (no code logic change) |
+| `refactor` | Restructuring without behavior change |
+| `test` | Adding or updating tests |
+| `chore` | Maintenance (dependencies, configs) |
+
+### Examples
+
+```bash
+# Feature
+git commit -m "feat(auth): add password reset flow"
+
+# Bug fix
+git commit -m "fix(api): handle null response from server"
+
+# Documentation
+git commit -m "docs(readme): add installation instructions"
+
+# Breaking change (note the !)
+git commit -m "feat(api)!: change authentication endpoint"
+```
+
+### Why Conventional Commits?
+
+1. **Automatic changelogs**: Tools can generate release notes
+2. **Clear history**: Easy to understand what changed and why
+3. **Semantic versioning**: Commit types inform version bumps
+4. **Better reviews**: Reviewers understand intent quickly
+
+---
+
+## Suggesting Features
+
+### Before Proposing
+
+1. **Search existing issues** - your idea may already be discussed
+2. **Check the roadmap** - it might be planned already
+3. **Consider scope** - does it fit the project's goals?
+
+### Priority Assessment
+
+When proposing features, consider these factors:
+
+| Factor | Questions to Ask |
+|--------|------------------|
+| **Impact** | How many users benefit? How significant is the improvement? |
+| **Effort** | How complex is implementation? What's the maintenance burden? |
+| **Risk** | What could break? Are there security implications? |
+| **Alignment** | Does it fit project goals and architecture? |
+
+### Feature Request Template
+
+```markdown
+## Problem Statement
+What problem does this solve?
+
+## Proposed Solution
+How should it work?
+
+## Alternatives Considered
+What other approaches exist?
+
+## Priority Assessment
+- Impact: [High/Medium/Low]
+- Effort: [High/Medium/Low]
+- Risk: [High/Medium/Low]
+```
+
+---
+
+## Code Review Process
+
+### What Reviewers Look For
+
+1. **Correctness**: Does the code do what it claims?
+2. **Tests**: Are changes covered by tests?
+3. **Style**: Does it follow project conventions?
+4. **Documentation**: Are changes documented?
+5. **Security**: Are there any vulnerabilities?
+6. **Performance**: Any performance implications?
+
+### Educational Review Criteria
+
+We review with education in mind:
+
+| Criteria | What We Check |
+|----------|---------------|
+| **Clarity** | Is the code readable and self-documenting? |
+| **Simplicity** | Is this the simplest solution that works? |
+| **Maintainability** | Will future contributors understand this? |
+| **Best Practices** | Does it follow established patterns? |
+
+### Responding to Feedback
+
+- **Be open**: Feedback improves code quality
+- **Ask questions**: If something is unclear, ask
+- **Iterate**: Multiple rounds of review are normal
+- **Learn**: Each review is a learning opportunity
+
+---
+
+## Pull Request Process
+
+### Before Submitting
+
+- [ ] Code compiles/runs without errors
+- [ ] Tests pass locally
+- [ ] Branch is up-to-date with main
+- [ ] Commit messages follow conventions
+- [ ] Documentation updated if needed
+
+### PR Description Template
+
+```markdown
+## Summary
+Brief description of changes.
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactoring
+
+## Testing
+How were changes tested?
+
+## Checklist
+- [ ] Tests added/updated
+- [ ] Documentation updated
+- [ ] No breaking changes (or documented)
+```
+
+### After Submitting
+
+1. **Respond to reviews** within a reasonable timeframe
+2. **Push fixes** as new commits (easier to review)
+3. **Request re-review** after addressing feedback
+4. **Squash commits** will happen on merge (if configured)
+
+---
+
+## Coding Standards
+
+### General Guidelines
+
+- Follow [PEP 8](https://peps.python.org/pep-0008/) style conventions
+- Write clear, self-documenting code; add comments only where logic is non-obvious
+- Keep functions focused and small
+- Follow existing patterns in the codebase
+
+### HAL-First Development Pattern
+
+The simulation framework uses a HAL (Hardware Abstraction Layer) to separate
+interface contracts from implementations. **Every mock class must implement an
+ABC (Abstract Base Class) defined in `simulation/hal/`.**
+
+When adding a new mock class:
+
+1. **Define the interface first** — add an ABC in the appropriate HAL module
+   (`simulation/hal/device.py`, `network.py`, or `platform.py`)
+2. **Commit the interface** before writing the implementation
+3. **Implement the mock** by subclassing the HAL ABC
+
+This order matters in both the code and the git history. The interface commit
+should always precede the implementation commit so that reviewers can evaluate
+the contract before the details.
+
+### Layer Isolation
+
+The simulation layers and HAL have a strict dependency rule:
+
+- **HAL** (`hal/`) must not import from any `layer` module
+- **Device layer** (`layer0/`) may import from `hal/` only
+- **Network layer** (`layer1/`) may import from `hal/` and `layer0/`
+- **Platform layer** (`layer2/`) may import from `hal/`, `layer0/`, and `layer1/`
+
+This is enforced structurally — a breaking change in the Platform layer must not affect the Device or Network layers.
+
+### Interface Compatibility
+
+Mock classes must implement their corresponding HAL ABC and be
+interface-compatible with their real hardware or service counterparts. This is
+what enables selective injection — the same component code runs against a real
+driver or a mock without modification. If you add a new method to a mock class,
+add it to the HAL ABC first, then implement it.
+
+### Testing Requirements
+
+Install dev dependencies and run the full test suite before submitting:
+
+```bash
+pip install -e ".[dev]"
+pytest tests/
+```
+
+- Unit tests are required for all new mock classes and public methods
+- Tests must pass for all layers: `pytest tests/` runs all three
+- Device layer tests must pass with no external runtime dependencies (no paho-mqtt, no flask, no network)
+
+---
+
+## Code of Conduct
+
+We are committed to providing a welcoming and inclusive environment.
+Please be respectful and constructive in all interactions.
+
+This project is part of the O.A.S.I.S. ecosystem. See the
+[S.C.O.P.E. meta-repository](https://github.com/malcolmhoward/the-oasis-project-meta-repo)
+for ecosystem-wide governance and conduct standards.
+
+---
+
+## Getting Help
+
+- **Questions about this repo**: Open an issue at [the-oasis-project-simulation-repo](https://github.com/malcolmhoward/the-oasis-project-simulation-repo/issues)
+- **Ecosystem questions**: Open an issue at [S.C.O.P.E.](https://github.com/malcolmhoward/the-oasis-project-meta-repo/issues)
+- **Bugs**: Open an issue with a description of the expected vs. actual behavior
+- **Features**: Open an issue describing the use case and which simulation layer it affects
+
+---
+
+---
+
+Generated with [Project Foundation Template](https://github.com/malcolmhoward/project-foundation-template)

--- a/FOUNDATION_NOTICE.md
+++ b/FOUNDATION_NOTICE.md
@@ -1,0 +1,41 @@
+# ETHICAL USE NOTICE
+
+This project foundation was generated on 2026-03-08T20:04:08.587421.
+
+The following templates were created:
+- README.md
+- CONTRIBUTING.md
+- LICENSE
+- .gitignore
+
+## Critical Reminders:
+
+1. **These are TEMPLATES** - They must be customized
+2. **This is NOT legal advice** - Consult professionals for compliance
+3. **This is NOT security consultation** - Implement actual security measures
+4. **Templates != Implementation** - You must actually follow these practices
+5. **Your responsibility** - You are liable for how you use these templates
+
+## Why These Notices Matter
+
+Every year, companies face penalties for:
+- Claiming false compliance (fraud)
+- Inadequate security practices (negligence)
+- Toxic project cultures (liability)
+- Misleading documentation (misrepresentation)
+
+Don't be a statistic. Use these templates as education and starting points,
+not as final solutions.
+
+## Next Steps
+
+1. Customize every template for your specific needs
+2. Review with appropriate professionals
+3. Implement the actual practices
+4. Keep them updated
+5. Keep learning
+
+---
+
+Generated with Project Foundation Generator 3.7.0
+Learn more: https://github.com/malcolmhoward/project-foundation-template

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,50 @@
+# Glossary
+
+Terminology used in the E.C.H.O. simulation framework. Entries are alphabetical.
+
+---
+
+**ABC (Abstract Base Class)**
+A Python class (from the `abc` module) that defines an interface contract. ABCs cannot be instantiated directly — subclasses must implement all abstract methods. In this project, ABCs define the HAL interfaces that mock implementations conform to.
+
+**BCM (Broadcom SOC Channel)**
+A GPIO pin numbering scheme that uses the Broadcom chip's internal channel numbers. One of two numbering modes supported by the RPi.GPIO library (the other being BOARD).
+
+**BOARD (Physical Pin Numbering)**
+A GPIO pin numbering scheme that uses the physical pin positions on the Raspberry Pi header. One of two numbering modes supported by the RPi.GPIO library (the other being BCM).
+
+**DAP2 (Dawn Audio Protocol 2.0)**
+A WebSocket-based protocol for distributed voice assistants in the D.A.W.N. ecosystem. Enables "smart satellites" — remote devices that run speech pipeline locally and send text queries to the central D.A.W.N. daemon.
+
+**GPIO (General-Purpose Input/Output)**
+Digital pins on a microcontroller or single-board computer that can be configured as either input or output. Used by S.P.A.R.K. for controlling actuators and reading digital sensors.
+
+**GPS (Global Positioning System)**
+A satellite-based navigation system that provides location and time information. M.I.R.A.G.E. and A.U.R.A. use GPS data for position tracking.
+
+**HAL (Hardware Abstraction Layer)**
+A set of interface contracts that decouple application code from specific hardware implementations. In E.C.H.O., the HAL defines abstract interfaces (in `simulation/hal/`) that both Python mock implementations and future C implementations must conform to.
+
+**I2C (Inter-Integrated Circuit)**
+A two-wire serial communication bus used to connect low-speed peripherals (sensors, displays, EEPROMs) to a microcontroller. Pronounced "I-squared-C" or "I-two-C". A.U.R.A. uses I2C for environmental sensor communication.
+
+**IMU (Inertial Measurement Unit)**
+A sensor package that measures acceleration, rotation, and sometimes magnetic field. Provides heading, pitch, and roll values. Used by M.I.R.A.G.E. for helmet orientation tracking.
+
+**LWT (Last Will and Testament)**
+An MQTT feature where a client registers a message with the broker at connect time. If the client disconnects unexpectedly, the broker publishes this message on the client's behalf — used for offline status detection in OCP.
+
+**MQTT (Message Queuing Telemetry Transport)**
+A lightweight publish-subscribe messaging protocol used for inter-component communication in O.A.S.I.S. Components publish and subscribe to topics (e.g., `hud/status`, `aura`) via an MQTT broker.
+
+**OCP (OASIS Communications Protocol)**
+The standardized messaging protocol used across O.A.S.I.S. components over MQTT. Defines status messages, discovery, command/response patterns, and keepalive heartbeats.
+
+**PCM (Pulse-Code Modulation)**
+A method for digitally representing analog audio signals. Raw audio data in E.C.H.O. is represented as 16-bit signed PCM samples — the standard format used by audio hardware and libraries.
+
+**SPI (Serial Peripheral Interface)**
+A synchronous serial communication bus used for short-distance communication between a microcontroller and peripherals. Faster than I2C but requires more wires (MOSI, MISO, SCLK, CS). S.P.A.R.K. uses SPI for high-speed sensor data.
+
+**VAD (Voice Activity Detection)**
+An algorithm that determines whether an audio signal contains human speech. Used by D.A.W.N. satellites to detect when a user has stopped speaking, triggering the end of a voice command.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,675 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,289 @@
+# O.A.S.I.S. Simulation Framework
+
+Software simulators for O.A.S.I.S. hardware, protocols, and services — develop and test without physical hardware or live external service dependencies.
+
+## Description
+
+The simulation framework provides drop-in replacements for the physical and software dependencies that O.A.S.I.S. components require at runtime:
+
+| Layer | What it simulates | Dependencies |
+|-------|------------------|--------------|
+| **Device** (`layer0`) | Hardware primitives — sensors, GPIO, I2C, SPI, camera, audio | None (stdlib only) |
+| **Network** (`layer1`) | Communication protocols — MQTT, DAP2 WebSocket, OCP messages | `paho-mqtt`, `websockets` |
+| **Platform** (`layer2`) | External software services — Home Assistant, LLM, memory/RAG | `flask` |
+
+Each layer is independent. If you only need sensor simulation, install the Device layer — no broker, no Flask, no network required.
+
+> **Layer naming note**: Device / Network / Platform are provisional names pending ecosystem review. Internal package directories use `layer0/`, `layer1/`, `layer2/`.
+
+## Who Is This For
+
+O.A.S.I.S. is designed to run on specialized hardware — NVIDIA Jetson,
+Raspberry Pi, custom sensor arrays. But the ideas behind it should not
+require hardware ownership as a prerequisite for contribution.
+
+The simulation framework lets you develop and test against the full O.A.S.I.S.
+software stack on a standard laptop, a modest desktop, a Chromebook, or a
+Windows or macOS machine. **No Jetson required. No GPU required. No external
+services required.**
+
+O.A.S.I.S. components have two distinct categories of dependency that can
+block contributors:
+
+- **Hardware dependencies** — GPIO, I2C, cameras, sensors, microphones
+- **Software service dependencies** — a local LLM (which requires Jetson-class
+  CPU or GPU for real inference), Home Assistant, real-time ASR, and a
+  memory/RAG system
+
+The simulation framework addresses both. The Device layer replaces hardware
+for any component (M.I.R.A.G.E., A.U.R.A., S.P.A.R.K., S.T.A.T.). The
+Platform layer replaces software services — using in-process Flask and SQLite
+mocks that carry no compute or memory floor. A developer on any platform can
+exercise the full O.A.S.I.S. software stack without any of those dependencies
+running. D.A.W.N. benefits the most (it uses all three layers), but every
+component has mock coverage.
+
+There are two ways to use the simulation framework:
+
+- **Python only** — install the simulation package with `pip` and develop
+  against it directly. Works on Linux, macOS, Windows (WSL2), and Chrome OS
+  (Crostini).
+- **Pre-built Docker image** — load a pre-built image and run it with
+  `docker compose up`. Works on Linux, **Windows (Docker Desktop)**, and
+  **macOS (Docker Desktop)** — no Linux required on the host. The container
+  is a self-contained Linux environment; `docker-compose` handles all
+  OS-specific differences.
+
+### Minimum hardware
+
+| Access path | RAM | GPU | Host OS | Notes |
+|-------------|:---:|:---:|---------|-------|
+| Python simulation | 4 GB | Not required | Linux, macOS, Windows (WSL2), Chrome OS (Crostini) | Suitable for classroom use |
+| Docker image | 4 GB | Not required | **Linux, Windows, macOS** — any OS with Docker | Full simulation stack; no build required on recipient machine |
+| Build locally | 8 GB | Not required | Linux (Debian/Ubuntu recommended) | Only needed for C/C++ source development |
+| Full target | 8 GB+ | Jetson GPU | Linux (JetPack) | Local LLM and real-time ASR viable |
+
+For the full breakdown — including classroom configurations, Docker image
+distribution, and component coverage by profile — see the
+[Development Environment Guide](https://github.com/malcolmhoward/the-oasis-project-meta-repo/blob/main/getting-started/DEVELOPMENT_ENVIRONMENT.md)
+in S.C.O.P.E.
+
+## Quick Start
+
+```bash
+# Device layer only (most common — hardware primitives, no extra deps)
+pip install -e .
+
+# Device + Network layers (adds protocol simulation)
+pip install -e ".[layer1]"
+
+# All layers
+pip install -e ".[all]"
+
+# Development (adds pytest)
+pip install -e ".[dev]"
+```
+
+Or, for Docker/CI without cloning:
+
+```bash
+pip install "git+https://github.com/malcolmhoward/the-oasis-project-simulation-repo.git"
+```
+
+```python
+from simulation.layer0.sensor import MockSensor
+
+sensor = MockSensor("imu", sensor_type="motion")
+data = sensor.read()
+print(data)
+# {"device": "Motion", "format": "Orientation", "heading": 45.2, "pitch": -2.1, "roll": 3.5, ...}
+```
+
+### Recommended Alias
+
+`simulation` is the full package name; `sim` is a natural shorthand:
+
+```python
+import simulation as sim
+
+imu    = sim.MockSensor("imu",    sensor_type="motion")
+gps    = sim.MockSensor("gps",    sensor_type="gps")
+enviro = sim.MockSensor("enviro", sensor_type="environmental")
+camera = sim.MockCamera(width=1920, height=1080, fps=30)
+gpio   = sim.MockGPIO()
+
+# Use just like the real hardware interfaces
+reading = imu.read()
+frame   = camera.capture()
+```
+
+## Documentation
+
+### Device Layer — Hardware Primitives
+
+#### MockSensor
+
+Generates time-varying sensor values matching O.A.S.I.S. MQTT message schemas.
+
+| `sensor_type` | MQTT `device` field | Key output fields |
+|---------------|--------------------|--------------------|
+| `"motion"` | `"Motion"` | `heading`, `pitch`, `roll`, `w`, `x`, `y`, `z` |
+| `"gps"` | `"GPS"` | `latitude`, `longitude`, `altitude`, `satellites`, `fix` |
+| `"environmental"` | `"Enviro"` | `temp`, `humidity`, `air_quality`, `tvoc_ppb`, `eco2_ppm`, `co2_ppm` |
+| `"temperature"` | *(generic)* | `temperature` |
+| `"humidity"` | *(generic)* | `humidity` |
+
+Values vary over time via sine-wave functions — each sensor has a random phase offset so they don't all move in lockstep.
+
+```python
+from simulation.layer0.sensor import MockSensor, MockSensorArray
+
+# Single sensor
+sensor = MockSensor("imu", sensor_type="motion")
+data = sensor.read()
+
+# Adjust simulated base values
+sensor.calibrate(heading=180.0, pitch=0.0)
+
+# Multiple sensors
+sensors = MockSensorArray()
+sensors.add_sensor("imu",    "motion")
+sensors.add_sensor("enviro", "environmental")
+all_readings = sensors.read_all()
+```
+
+#### MockGPIO
+
+API-compatible with `RPi.GPIO` (class-method interface).
+
+```python
+from simulation.layer0.gpio import MockGPIO
+
+MockGPIO.setmode(MockGPIO.BCM)
+MockGPIO.setup(17, MockGPIO.OUT)
+MockGPIO.output(17, MockGPIO.HIGH)
+value = MockGPIO.input(17)
+MockGPIO.cleanup()
+```
+
+#### MockI2C
+
+256-byte register array per device address.
+
+```python
+from simulation.layer0.i2c import MockI2C
+
+bus = MockI2C(bus_number=1)
+bus.write_byte_data(0x68, 0x6B, 0x00)   # wake MPU-6050
+whoami = bus.read_byte_data(0x68, 0x75)
+```
+
+#### MockSPI
+
+Loopback by default; supports pluggable response handlers for device-specific behaviour.
+
+```python
+from simulation.layer0.spi import MockSPI
+
+with MockSPI(bus=0, device=0) as spi:
+    response = spi.transfer([0xD0, 0x00])  # echoed back by default
+
+# Custom device response
+def bme280_id(data):
+    if data[0] == 0xD0:
+        return [0x60, 0x00]  # WHO_AM_I for BME280
+    return [0x00] * len(data)
+
+spi = MockSPI(response_handler=bme280_id)
+```
+
+#### MockCamera
+
+Returns frame metadata dicts (no actual pixel data needed for most tests).
+
+```python
+from simulation.layer0.camera import MockCamera
+
+with MockCamera(device_id=0, width=1920, height=1080, fps=30) as cam:
+    frame = cam.capture()
+    print(frame["frame_number"], frame["brightness"])
+```
+
+#### MockMicrophone / MockSpeaker
+
+```python
+from simulation.layer0.audio import MockMicrophone, MockSpeaker
+
+mic = MockMicrophone(sample_rate=16_000, channels=1, chunk_size=1024)
+mic.start()
+pcm_bytes = mic.read()   # 16-bit signed PCM, little-endian
+mic.stop()
+
+speaker = MockSpeaker(sample_rate=16_000)
+speaker.start()
+speaker.write(pcm_bytes)  # null sink — discards audio
+speaker.stop()
+```
+
+### Network Layer — Protocol Simulation
+
+> Network layer is under active development. See `simulation/layer1/` for current status.
+
+Enables testing of O.A.S.I.S. protocol interactions without live hardware:
+
+- **`mqtt.py`** — MQTT topic publisher/subscriber helpers with message serializers
+- **`ocp.py`** — OCP (O.A.S.I.S. Communications Protocol) request/response builder
+- **`dap2_client.py`** — DAP2 satellite WebSocket client (register, query, text-path command injection)
+
+### Platform Layer — Software Service Simulation
+
+> Platform layer is under active development. See `simulation/layer2/` for current status.
+
+In-process Flask servers and deterministic stubs for external services:
+
+- **`ha_mock.py`** — Home Assistant REST API mock (`/api/states`, `/api/services/...`)
+- **`llm_mock.py`** — LLM response simulator (keyword → tool call synthesis, streaming)
+- **`memory_mock.py`** — Memory/RAG stub (SQLite-backed fact store, keyword retrieval)
+
+### Running Tests
+
+```bash
+# Install with dev dependencies first
+pip install -e ".[dev]"
+
+# Run all tests
+pytest
+
+# Run Device layer tests only
+pytest tests/test_layer0.py -v
+```
+
+### Integration with Component Repos
+
+This repository is designed for use as a **git submodule** in O.A.S.I.S. component repos:
+
+```bash
+# In a component repo
+git submodule add https://github.com/malcolmhoward/the-oasis-project-simulation-repo simulation_framework
+cd simulation_framework && pip install -e .
+```
+
+## Status
+
+| Layer | Status |
+|-------|--------|
+| Device — Hardware primitives | **Available** |
+| Network — Protocol simulation | In development |
+| Platform — Service simulation | In development |
+
+## Contributing
+
+Please see [CONTRIBUTING.md](CONTRIBUTING.md) for the fork-first workflow, branch naming conventions, and code review process.
+
+## License
+
+GPL-3.0. This project is part of the O.A.S.I.S. ecosystem; all O.A.S.I.S. component repositories use the GNU General Public License v3.0. See [LICENSE](LICENSE).
+
+## Security
+
+For security concerns, please open a private issue or contact the maintainers via the [O.A.S.I.S. meta-repository](https://github.com/malcolmhoward/the-oasis-project-meta-repo).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,124 @@
+# API Reference
+
+Class and method documentation for the simulation framework. Each layer's section is added alongside its implementation.
+
+## HAL (Hardware Abstraction Layer) — Interface Contracts
+
+### `simulation.hal.device`
+
+| Interface | Methods | Description |
+|-----------|---------|-------------|
+| `SensorInterface` | `read()`, `calibrate(**kwargs)`, `activate()`, `deactivate()`, `reset()` | Sensor that produces periodic readings as a string-keyed map |
+| `SensorArrayInterface` | `add_sensor(name, type)`, `remove_sensor(name)`, `read_all()`, `read_sensor(name)`, `list_sensors()` | Named collection of sensors |
+| `GPIOInterface` | `setmode(mode)`, `getmode()`, `setup(pin, mode, ...)`, `output(pin, value)`, `input(pin)`, `cleanup(pin)` | GPIO (General-Purpose Input/Output) pin control |
+| `I2CInterface` | `write_byte_data(addr, reg, val)`, `read_byte_data(addr, reg)`, `write_i2c_block_data(...)`, `read_i2c_block_data(...)`, `write_byte(addr, val)`, `read_byte(addr)`, `close()` | I2C (Inter-Integrated Circuit) bus |
+| `SPIInterface` | `transfer(data)`, `read(length)`, `write(data)`, `close()` | SPI (Serial Peripheral Interface) bus |
+| `CameraInterface` | `capture()`, `set_resolution(w, h)`, `set_fps(fps)`, `get_properties()`, `release()` | Video capture device |
+| `MicrophoneInterface` | `start()`, `stop()`, `read()` | Audio input (returns PCM byte array) |
+| `SpeakerInterface` | `start()`, `stop()`, `write(data)` | Audio output (accepts PCM byte array) |
+
+### `simulation.hal.provider`
+
+| Class | Methods | Description |
+|-------|---------|-------------|
+| `Provider(initial, on_swap)` | `swap(new_impl)`, `implementation`, `implementation_type` | Runtime hot-swap wrapper; forwards all attribute access to the active implementation. Thread-safe. |
+
+---
+
+## Device Layer — `simulation.layer0`
+
+### `MockSensor(SensorInterface)`
+
+Generates time-varying sensor values matching O.A.S.I.S. MQTT message schemas.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `name` | string | `"sensor"` | Sensor identifier |
+| `sensor_type` | string | `"generic"` | Type: `"motion"`, `"gps"`, `"environmental"`, `"temperature"`, `"humidity"`, `"pressure"` |
+| `update_interval` | float | `0.0` | Minimum seconds between reads |
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `read()` | string-keyed map | Sensor reading; schema depends on `sensor_type` |
+| `calibrate(**kwargs)` | None | Override base values (e.g., `heading=180.0`) |
+| `activate()` / `deactivate()` | None | Enable/disable the sensor |
+| `reset()` | None | Reset reading count and timer |
+
+### `MockSensorArray(SensorArrayInterface)`
+
+Named collection of `MockSensor` instances.
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `add_sensor(name, sensor_type)` | `MockSensor` | Create and register a sensor |
+| `remove_sensor(name)` | None | Remove by name |
+| `read_all()` | map of name → reading | Read all sensors |
+| `read_sensor(name)` | string-keyed map | Read one sensor |
+| `list_sensors()` | list of strings | All registered names |
+
+### `MockGPIO(GPIOInterface)`
+
+RPi.GPIO-compatible class-method API.
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `BCM` | `"BCM"` | Broadcom SOC channel numbering |
+| `BOARD` | `"BOARD"` | Physical pin numbering |
+| `IN` / `OUT` | `"in"` / `"out"` | Pin directions |
+| `HIGH` / `LOW` | `1` / `0` | Pin values |
+
+All methods are class methods: `setmode()`, `getmode()`, `setup()`, `output()`, `input()`, `cleanup()`, `add_event_detect()`, `remove_event_detect()`.
+
+### `MockI2C(I2CInterface)`
+
+256-byte register array per device address.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `bus_number` | integer | `1` | I2C bus number |
+
+### `MockSPI(SPIInterface)`
+
+Loopback by default; pluggable response handlers.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `bus` | integer | `0` | SPI bus |
+| `device` | integer | `0` | SPI device (chip select) |
+| `max_speed_hz` | integer | `500000` | Clock speed |
+| `mode` | integer | `0` | SPI mode (0-3) |
+| `response_handler` | callable or None | `None` | Custom response: `(data: list[int]) -> list[int]` |
+
+### `MockCamera(CameraInterface)`
+
+Returns frame metadata dicts (no pixel data).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `device_id` | integer | `0` | Camera device ID |
+| `width` | integer | `1920` | Frame width in pixels |
+| `height` | integer | `1080` | Frame height in pixels |
+| `fps` | integer | `30` | Frames per second |
+
+`capture()` returns: `frame_number`, `timestamp`, `elapsed_time`, `width`, `height`, `device_id`, `fps`, `brightness`, `contrast`, `data`.
+
+### `MockMicrophone(MicrophoneInterface)`
+
+Synthetic sine-wave PCM (Pulse-Code Modulation) audio source.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `sample_rate` | integer | `16000` | Samples per second |
+| `channels` | integer | `1` | Audio channels |
+| `chunk_size` | integer | `1024` | Samples per read() call |
+| `frequency_hz` | float | `440.0` | Sine wave frequency |
+| `amplitude` | float | `0.3` | Signal amplitude (0.0-1.0) |
+
+### `MockSpeaker(SpeakerInterface)`
+
+Null-sink audio output.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `sample_rate` | integer | `16000` | Samples per second |
+| `channels` | integer | `1` | Audio channels |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "oasis-simulation"
+version = "0.1.0"
+description = "Simulation framework for O.A.S.I.S. development and testing without physical hardware or live external services"
+requires-python = ">=3.10"
+license = { text = "GPL-3.0-or-later" }
+readme = "README.md"
+
+# Layer 0 has no runtime dependencies beyond the standard library.
+# numpy is optional (only needed if callers want to convert frame data to arrays).
+dependencies = []
+
+[project.optional-dependencies]
+# Layer 1: protocol simulation
+layer1 = [
+    "paho-mqtt>=1.6.1",
+    "websockets>=11.0",
+]
+# Layer 2: software behavior simulation
+layer2 = [
+    "flask>=3.0",
+]
+# Full install (all layers)
+all = [
+    "paho-mqtt>=1.6.1",
+    "websockets>=11.0",
+    "flask>=3.0",
+]
+# Development / testing
+dev = [
+    "pytest>=7.0",
+    "pytest-cov",
+]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["simulation*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/simulation/__init__.py
+++ b/simulation/__init__.py
@@ -1,0 +1,44 @@
+"""
+simulation — O.A.S.I.S. simulation framework for development and testing.
+
+Layer 0 (Hardware primitives — no external runtime deps beyond stdlib):
+
+    from simulation.layer0.sensor import MockSensor, MockSensorArray
+    from simulation.layer0.gpio   import MockGPIO
+    from simulation.layer0.i2c    import MockI2C
+    from simulation.layer0.spi    import MockSPI
+    from simulation.layer0.camera import MockCamera
+    from simulation.layer0.audio  import MockMicrophone, MockSpeaker
+
+Layer 1 (Protocol simulation — requires paho-mqtt, websockets):
+
+    from simulation.layer1.mqtt        import MQTTPublisher
+    from simulation.layer1.ocp         import OCPBuilder
+    from simulation.layer1.dap2_client import DAP2Client
+
+Layer 2 (Software behavior — requires flask; optional LLM/memory deps):
+
+    from simulation.layer2.ha_mock     import HomeAssistantMock
+    from simulation.layer2.llm_mock    import LLMMock
+    from simulation.layer2.memory_mock import MemoryMock
+
+Top-level convenience imports (Layer 0 only — safe for all environments):
+"""
+
+from simulation.layer0.sensor import MockSensor, MockSensorArray
+from simulation.layer0.gpio   import MockGPIO
+from simulation.layer0.i2c    import MockI2C
+from simulation.layer0.spi    import MockSPI
+from simulation.layer0.camera import MockCamera
+from simulation.layer0.audio  import MockMicrophone, MockSpeaker
+
+__all__ = [
+    "MockSensor",
+    "MockSensorArray",
+    "MockGPIO",
+    "MockI2C",
+    "MockSPI",
+    "MockCamera",
+    "MockMicrophone",
+    "MockSpeaker",
+]

--- a/simulation/hal/__init__.py
+++ b/simulation/hal/__init__.py
@@ -1,0 +1,21 @@
+"""
+HAL (Hardware Abstraction Layer) — interface contracts for the simulation framework.
+
+Each module defines ABCs (Abstract Base Classes) that both Python mock
+implementations and future C HAL headers must conform to.  The dependency
+flows one way: implementation layers (layer0, layer1, layer2) import from
+hal, never the reverse.
+
+Language note:
+    These interfaces are defined as Python ABCs, but the docstrings describe
+    parameters and return values in language-neutral terms (e.g., "integer",
+    "byte array", "string-keyed map") so that C HAL headers can be derived
+    directly from the same descriptions in Phase 2.  No separate IDL
+    (Interface Definition Language) or specification format is needed — the
+    ABCs are the single source of truth.
+
+Modules:
+    device   — Sensor, GPIO, I2C, SPI, Camera, Audio interfaces (Layer 0)
+    network  — MQTT, OCP, DAP2 interfaces (Layer 1)
+    platform — Home Assistant, LLM, Memory interfaces (Layer 2)
+"""

--- a/simulation/hal/device.py
+++ b/simulation/hal/device.py
@@ -1,0 +1,349 @@
+"""
+Device layer interface contracts — hardware primitive abstractions.
+
+These ABCs (Abstract Base Classes) define the API that both Python mock
+implementations (Layer 0) and future C HAL (Hardware Abstraction Layer)
+headers (Phase 2) must conform to.  The interfaces are derived from the
+real hardware APIs used by O.A.S.I.S. components:
+
+- SensorInterface: IMU (Inertial Measurement Unit), GPS (Global Positioning
+  System), environmental sensors (M.I.R.A.G.E., A.U.R.A., S.T.A.T.)
+- GPIOInterface: GPIO (General-Purpose Input/Output) pin control (S.P.A.R.K.)
+- I2CInterface: I2C (Inter-Integrated Circuit) bus (A.U.R.A.)
+- SPIInterface: SPI (Serial Peripheral Interface) bus (S.P.A.R.K.)
+- CameraInterface: Video capture devices (M.I.R.A.G.E.)
+- MicrophoneInterface / SpeakerInterface: Audio I/O (D.A.W.N. satellite)
+
+Docstrings use language-neutral descriptions so C HAL headers can be derived
+from the same definitions.  Python type annotations are present for static
+analysis but are not the authoritative specification — the docstrings are.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Sensor
+# ---------------------------------------------------------------------------
+
+
+class SensorInterface(ABC):
+    """Interface for a sensor that produces periodic readings.
+
+    Implementations must support at minimum: read(), activate(), deactivate().
+    A string ``sensor_type`` attribute determines the schema of the returned map.
+    """
+
+    @abstractmethod
+    def read(self) -> Dict[str, Any]:
+        """Return a single sensor reading as a string-keyed map.
+
+        The map keys depend on the sensor type.  Motion readings include
+        ``heading`` (float, degrees 0-360), ``pitch`` (float, degrees),
+        ``roll`` (float, degrees).  GPS readings include ``latitude`` (float),
+        ``longitude`` (float), ``satellites`` (integer).
+        """
+        ...
+
+    @abstractmethod
+    def calibrate(self, **kwargs: Any) -> None:
+        """Override base values used for readings.
+
+        Accepts named parameters matching internal base values (e.g.,
+        ``temperature=22.5``, ``heading=90.0``).  Unknown names are ignored.
+        """
+        ...
+
+    @abstractmethod
+    def activate(self) -> None:
+        """Enable the sensor for reading."""
+        ...
+
+    @abstractmethod
+    def deactivate(self) -> None:
+        """Disable the sensor.  Subsequent read() calls should raise an error."""
+        ...
+
+    @abstractmethod
+    def reset(self) -> None:
+        """Reset internal counters and timers to initial state."""
+        ...
+
+
+class SensorArrayInterface(ABC):
+    """Interface for a named collection of sensors."""
+
+    @abstractmethod
+    def add_sensor(self, name: str, sensor_type: str = "generic") -> SensorInterface:
+        """Create and register a sensor under the given string name.
+
+        Returns the created sensor instance.
+        """
+        ...
+
+    @abstractmethod
+    def remove_sensor(self, name: str) -> None:
+        """Remove a sensor by string name.  No error if name is absent."""
+        ...
+
+    @abstractmethod
+    def read_all(self) -> Dict[str, Dict[str, Any]]:
+        """Read all sensors.  Returns a map of name to reading map."""
+        ...
+
+    @abstractmethod
+    def read_sensor(self, name: str) -> Dict[str, Any]:
+        """Read a single sensor by name.  Raises an error if name is absent."""
+        ...
+
+    @abstractmethod
+    def list_sensors(self) -> List[str]:
+        """Return the names of all registered sensors as a list of strings."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# GPIO
+# ---------------------------------------------------------------------------
+
+
+class GPIOInterface(ABC):
+    """Interface for GPIO (General-Purpose Input/Output) pin control.
+
+    Modeled after RPi.GPIO (the Raspberry Pi GPIO library).  Implementations
+    may use class methods (for RPi.GPIO drop-in compatibility) or instance
+    methods — the abstract interface uses instance methods as the
+    language-independent baseline.
+
+    Implementing classes should define constants for:
+    - Pin numbering modes: ``BCM`` (Broadcom SOC channel), ``BOARD`` (physical pin)
+    - Pin directions: ``IN``, ``OUT``
+    - Pin values: ``HIGH`` (1), ``LOW`` (0)
+    """
+
+    @abstractmethod
+    def setmode(self, mode: str) -> None:
+        """Set the pin numbering mode.  Accepts a mode string (e.g., "BCM" or "BOARD")."""
+        ...
+
+    @abstractmethod
+    def getmode(self) -> Optional[str]:
+        """Return the current pin numbering mode as a string, or null/None if unset."""
+        ...
+
+    @abstractmethod
+    def setup(self, pin: int, mode: str, pull_up_down: int = 0,
+              initial: Optional[int] = None) -> None:
+        """Configure a pin.
+
+        Parameters (language-neutral):
+            pin: integer pin number
+            mode: string direction ("in" or "out")
+            pull_up_down: integer pull resistor mode (0=off, 1=down, 2=up)
+            initial: optional integer initial value (0 or 1) for output pins
+        """
+        ...
+
+    @abstractmethod
+    def output(self, pin: int, value: int) -> None:
+        """Set an output pin value.  pin: integer, value: integer (0=LOW, 1=HIGH)."""
+        ...
+
+    @abstractmethod
+    def input(self, pin: int) -> int:
+        """Read a pin value.  Returns integer (0 or 1)."""
+        ...
+
+    @abstractmethod
+    def cleanup(self, pin: Optional[int] = None) -> None:
+        """Release one pin (integer) or all pins (null/None)."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# I2C
+# ---------------------------------------------------------------------------
+
+
+class I2CInterface(ABC):
+    """Interface for an I2C (Inter-Integrated Circuit) bus with register-addressed devices.
+
+    All addresses and register values are unsigned integers.  Byte values
+    are integers in the range 0-255.
+    """
+
+    @abstractmethod
+    def write_byte_data(self, addr: int, register: int, value: int) -> None:
+        """Write one byte (integer 0-255) to a device register.
+
+        addr: integer device address, register: integer register address,
+        value: integer byte value.
+        """
+        ...
+
+    @abstractmethod
+    def read_byte_data(self, addr: int, register: int) -> int:
+        """Read one byte from a device register.  Returns integer 0-255."""
+        ...
+
+    @abstractmethod
+    def write_i2c_block_data(self, addr: int, register: int, data: List[int]) -> None:
+        """Write an array of bytes starting at the given register.
+
+        data: array of integers (each 0-255).
+        """
+        ...
+
+    @abstractmethod
+    def read_i2c_block_data(self, addr: int, register: int, length: int) -> List[int]:
+        """Read an array of bytes starting at the given register.
+
+        length: integer count of bytes to read.  Returns array of integers (each 0-255).
+        """
+        ...
+
+    @abstractmethod
+    def write_byte(self, addr: int, value: int) -> None:
+        """Write a single byte with no register address.  value: integer 0-255."""
+        ...
+
+    @abstractmethod
+    def read_byte(self, addr: int) -> int:
+        """Read a single byte with no register address.  Returns integer 0-255."""
+        ...
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release the bus."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# SPI
+# ---------------------------------------------------------------------------
+
+
+class SPIInterface(ABC):
+    """Interface for an SPI (Serial Peripheral Interface) bus device.
+
+    All data values are arrays of integers (each 0-255), representing bytes.
+    """
+
+    @abstractmethod
+    def transfer(self, data: List[int]) -> List[int]:
+        """Simultaneously send and receive bytes.
+
+        data: array of integers (each 0-255).  Returns response as an array of
+        the same length.
+        """
+        ...
+
+    @abstractmethod
+    def read(self, length: int) -> List[int]:
+        """Read bytes by sending zeros.
+
+        length: integer count.  Returns array of integers (each 0-255).
+        """
+        ...
+
+    @abstractmethod
+    def write(self, data: List[int]) -> None:
+        """Write bytes, discarding the response.  data: array of integers (each 0-255)."""
+        ...
+
+    @abstractmethod
+    def close(self) -> None:
+        """Release the SPI device."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Camera
+# ---------------------------------------------------------------------------
+
+
+class CameraInterface(ABC):
+    """Interface for a video capture device."""
+
+    @abstractmethod
+    def capture(self) -> Dict[str, Any]:
+        """Capture a single frame.
+
+        Returns a string-keyed map containing at minimum: ``frame_number``
+        (integer), ``timestamp`` (float, seconds since epoch), ``width``
+        (integer, pixels), ``height`` (integer, pixels).
+        """
+        ...
+
+    @abstractmethod
+    def set_resolution(self, width: int, height: int) -> None:
+        """Change the capture resolution.  width and height: integers in pixels."""
+        ...
+
+    @abstractmethod
+    def set_fps(self, fps: int) -> None:
+        """Change the capture frame rate.  fps: integer frames per second."""
+        ...
+
+    @abstractmethod
+    def get_properties(self) -> Dict[str, Any]:
+        """Return current device properties as a string-keyed map."""
+        ...
+
+    @abstractmethod
+    def release(self) -> None:
+        """Release the camera device."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Audio
+# ---------------------------------------------------------------------------
+
+
+class MicrophoneInterface(ABC):
+    """Interface for an audio input device."""
+
+    @abstractmethod
+    def start(self) -> None:
+        """Begin capturing audio."""
+        ...
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Stop capturing audio."""
+        ...
+
+    @abstractmethod
+    def read(self) -> bytes:
+        """Return one chunk of PCM (Pulse-Code Modulation) audio data as a byte array.
+
+        Format: 16-bit signed samples, little-endian.  The number of samples
+        per chunk is implementation-defined.
+        """
+        ...
+
+
+class SpeakerInterface(ABC):
+    """Interface for an audio output device (may be a null sink in simulation)."""
+
+    @abstractmethod
+    def start(self) -> None:
+        """Begin accepting audio for playback."""
+        ...
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Stop playback."""
+        ...
+
+    @abstractmethod
+    def write(self, data: bytes) -> int:
+        """Accept PCM (Pulse-Code Modulation) audio data as a byte array.
+
+        Returns the number of bytes accepted (integer).
+        """
+        ...

--- a/simulation/hal/provider.py
+++ b/simulation/hal/provider.py
@@ -1,0 +1,140 @@
+"""
+Provider — manages the active implementation behind a HAL interface and
+supports runtime hot-swap between mock and real backends.
+
+The Provider sits above the HAL interfaces. It holds a reference to the
+currently active implementation, forwards all attribute access to it, and
+supports swapping the backend at runtime without restarting the component.
+
+This enables the three injection modes described in ADR-0003 Amendment 4:
+
+1. **Default injection** — Provider wraps a mock at creation time.
+2. **Explicit injection** — Caller passes a specific implementation at creation.
+3. **Runtime injection** — Caller calls ``swap()`` after creation to change
+   the active backend (e.g., USB camera plugged in → swap MockCamera for
+   real camera driver).
+
+The Provider emits optional callbacks on swap events, enabling components
+to react to backend changes (e.g., update a status display, log the
+transition, notify other components via OCP).
+
+Language-neutral design note:
+    The Provider is a thin wrapper with no protocol-specific logic. In Python
+    it uses ``__getattr__`` delegation. A C equivalent would be a struct
+    holding a function pointer table (the HAL interface) plus a swap function
+    that replaces the table pointer.
+
+Example::
+
+    from simulation.hal.provider import Provider
+    from simulation.hal.device import CameraInterface
+    from simulation.layer0.camera import MockCamera
+
+    # Start with mock
+    camera_provider = Provider(MockCamera(device_id=0))
+
+    # Use it — all CameraInterface methods are forwarded
+    frame = camera_provider.capture()
+
+    # Later: real camera becomes available
+    real_camera = RealCamera(device_id=0)
+    camera_provider.swap(real_camera)
+
+    # Subsequent calls go to the real camera
+    frame = camera_provider.capture()
+
+    # Camera disconnected — fall back to mock
+    camera_provider.swap(MockCamera(device_id=0))
+
+Example with swap callback::
+
+    def on_swap(old_impl, new_impl):
+        print(f"Backend changed: {type(old_impl).__name__} → {type(new_impl).__name__}")
+
+    provider = Provider(MockCamera(), on_swap=on_swap)
+    provider.swap(RealCamera())
+    # prints: Backend changed: MockCamera → RealCamera
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable, Generic, Optional, TypeVar
+
+T = TypeVar("T")
+
+
+class Provider(Generic[T]):
+    """Runtime-swappable wrapper for any HAL interface implementation.
+
+    Parameters
+    ----------
+    initial : T
+        The initial implementation (typically a mock).
+    on_swap : callable, optional
+        Callback invoked as ``on_swap(old_implementation, new_implementation)``
+        whenever the backend is swapped. Called under the provider's lock,
+        so it should be fast and non-blocking.
+    """
+
+    def __init__(
+        self,
+        initial: T,
+        on_swap: Optional[Callable[[T, T], None]] = None,
+    ) -> None:
+        self._impl: T = initial
+        self._on_swap = on_swap
+        self._lock = threading.RLock()
+
+    @property
+    def implementation(self) -> T:
+        """The currently active implementation."""
+        with self._lock:
+            return self._impl
+
+    @property
+    def implementation_type(self) -> type:
+        """The type of the currently active implementation."""
+        with self._lock:
+            return type(self._impl)
+
+    def swap(self, new_impl: T) -> T:
+        """Replace the active implementation. Returns the old implementation.
+
+        Thread-safe. If an ``on_swap`` callback was provided at creation,
+        it is called with (old_implementation, new_implementation) under
+        the lock.
+
+        Parameters
+        ----------
+        new_impl : T
+            The new implementation to activate.
+
+        Returns
+        -------
+        T
+            The previous implementation (caller may want to clean it up).
+        """
+        with self._lock:
+            old = self._impl
+            self._impl = new_impl
+            if self._on_swap is not None:
+                self._on_swap(old, new_impl)
+            return old
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward attribute access to the active implementation.
+
+        This allows the Provider to be used as a drop-in replacement for
+        the underlying interface — callers call ``provider.read()`` instead
+        of ``provider.implementation.read()``.
+        """
+        # Avoid infinite recursion for attributes used during __init__
+        if name.startswith("_"):
+            raise AttributeError(name)
+        with self._lock:
+            return getattr(self._impl, name)
+
+    def __repr__(self) -> str:
+        with self._lock:
+            return f"Provider({self._impl!r})"

--- a/simulation/hal/status.py
+++ b/simulation/hal/status.py
@@ -1,0 +1,324 @@
+"""
+SimulationStatus — centralized tracker for which interfaces are running on
+simulated vs. real implementations.
+
+Emits events when status changes occur (Provider swaps, startup, shutdown),
+enabling multiple notification channels to react:
+
+- Structured logging (always on)
+- MQTT broadcast to ``echo/status`` topic
+- TTS announcements via D.A.W.N. (``dawn`` MQTT topic)
+- Audio alerts via M.I.R.A.G.E. (``hud`` MQTT topic)
+- WebUI notifications (via WebSocket or HTTP endpoint)
+- HUD visual indicators (consume ``echo/status`` messages)
+
+The tracker is decoupled from notification delivery — it publishes events
+through registered listeners. Components register the channels they support.
+
+Language-neutral design note:
+    The tracker maintains a string-keyed map of interface names to status
+    records. Each record contains: interface name (string), implementation
+    type name (string), is_simulated (boolean), and timestamp (float,
+    seconds since epoch). A C equivalent would be a struct array with a
+    callback function pointer for change notifications.
+
+Example::
+
+    from simulation.hal.status import SimulationStatus, StatusEvent
+    from simulation.hal.provider import Provider
+    from simulation.layer0.camera import MockCamera
+
+    tracker = SimulationStatus()
+
+    # Register a listener (any callable that accepts a StatusEvent)
+    tracker.add_listener(lambda event: print(f"{event.interface}: {event.message}"))
+
+    # Wire a Provider to the tracker
+    camera = Provider(
+        MockCamera(),
+        on_swap=tracker.create_swap_handler("camera"),
+    )
+
+    # Swap triggers the listener
+    camera.swap(MockCamera(device_id=1))
+    # prints: camera: Swapped from MockCamera to MockCamera
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class StatusChange(Enum):
+    """Type of simulation status change."""
+    REGISTERED = "registered"
+    SWAPPED = "swapped"
+    UNREGISTERED = "unregistered"
+
+
+@dataclass
+class StatusRecord:
+    """Current status of a single interface."""
+    interface: str
+    implementation: str
+    is_simulated: bool
+    timestamp: float = field(default_factory=time.time)
+
+
+@dataclass
+class StatusEvent:
+    """Event emitted when simulation status changes."""
+    change: StatusChange
+    interface: str
+    implementation: str
+    previous_implementation: Optional[str]
+    is_simulated: bool
+    was_simulated: Optional[bool]
+    timestamp: float = field(default_factory=time.time)
+
+    @property
+    def message(self) -> str:
+        """Human-readable description of the change."""
+        if self.change == StatusChange.REGISTERED:
+            mode = "simulated" if self.is_simulated else "live"
+            return f"{self.interface} registered as {mode} ({self.implementation})"
+        elif self.change == StatusChange.SWAPPED:
+            old_mode = "simulated" if self.was_simulated else "live"
+            new_mode = "simulated" if self.is_simulated else "live"
+            if old_mode != new_mode:
+                return (f"{self.interface} switched from {old_mode} to {new_mode} "
+                        f"({self.previous_implementation} to {self.implementation})")
+            return (f"{self.interface} swapped implementation "
+                    f"({self.previous_implementation} to {self.implementation})")
+        elif self.change == StatusChange.UNREGISTERED:
+            return f"{self.interface} unregistered"
+        return f"{self.interface}: {self.change.value}"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a string-keyed map for MQTT/JSON publishing."""
+        return {
+            "change": self.change.value,
+            "interface": self.interface,
+            "implementation": self.implementation,
+            "previous_implementation": self.previous_implementation,
+            "is_simulated": self.is_simulated,
+            "was_simulated": self.was_simulated,
+            "timestamp": self.timestamp,
+            "message": self.message,
+        }
+
+
+# Type alias for event listeners
+StatusListener = Callable[[StatusEvent], None]
+
+
+def is_mock_implementation(impl: Any) -> bool:
+    """Heuristic to determine if an implementation is a mock.
+
+    Returns true if the class name starts with "Mock" or the module path
+    contains "simulation.layer". Override by setting a ``_is_simulated``
+    attribute on the implementation.
+    """
+    if hasattr(impl, "_is_simulated"):
+        return bool(impl._is_simulated)
+    name = type(impl).__name__
+    module = type(impl).__module__ or ""
+    return name.startswith("Mock") or "simulation.layer" in module
+
+
+class SimulationStatus:
+    """Centralized tracker for simulation vs. real implementation status.
+
+    Thread-safe. Maintains a registry of interface names and their current
+    status. Emits events to registered listeners on every status change.
+
+    Parameters
+    ----------
+    name : str
+        Identifier for this tracker instance (e.g., component name).
+    """
+
+    def __init__(self, name: str = "default") -> None:
+        self.name = name
+        self._interfaces: Dict[str, StatusRecord] = {}
+        self._listeners: List[StatusListener] = []
+        self._lock = threading.RLock()
+
+        # Always log events
+        self.add_listener(self._log_listener)
+
+    # ------------------------------------------------------------------
+    # Interface registration
+    # ------------------------------------------------------------------
+
+    def register(self, interface: str, implementation: Any) -> None:
+        """Register an interface with its current implementation.
+
+        Emits a REGISTERED event to all listeners.
+        """
+        simulated = is_mock_implementation(implementation)
+        record = StatusRecord(
+            interface=interface,
+            implementation=type(implementation).__name__,
+            is_simulated=simulated,
+        )
+        event = StatusEvent(
+            change=StatusChange.REGISTERED,
+            interface=interface,
+            implementation=record.implementation,
+            previous_implementation=None,
+            is_simulated=simulated,
+            was_simulated=None,
+        )
+        with self._lock:
+            self._interfaces[interface] = record
+            self._emit(event)
+
+    def unregister(self, interface: str) -> None:
+        """Remove an interface from the tracker.
+
+        Emits an UNREGISTERED event if the interface was tracked.
+        """
+        with self._lock:
+            record = self._interfaces.pop(interface, None)
+            if record:
+                self._emit(StatusEvent(
+                    change=StatusChange.UNREGISTERED,
+                    interface=interface,
+                    implementation=record.implementation,
+                    previous_implementation=None,
+                    is_simulated=record.is_simulated,
+                    was_simulated=None,
+                ))
+
+    # ------------------------------------------------------------------
+    # Provider integration
+    # ------------------------------------------------------------------
+
+    def create_swap_handler(self, interface: str) -> Callable:
+        """Create an ``on_swap`` callback for a Provider.
+
+        Returns a callable suitable for ``Provider(impl, on_swap=handler)``.
+        The handler updates the tracker and emits a SWAPPED event.
+
+        Parameters
+        ----------
+        interface : str
+            The interface name to track (e.g., "camera", "sensor.imu").
+        """
+        def handler(old_impl: Any, new_impl: Any) -> None:
+            old_simulated = is_mock_implementation(old_impl)
+            new_simulated = is_mock_implementation(new_impl)
+            record = StatusRecord(
+                interface=interface,
+                implementation=type(new_impl).__name__,
+                is_simulated=new_simulated,
+            )
+            event = StatusEvent(
+                change=StatusChange.SWAPPED,
+                interface=interface,
+                implementation=type(new_impl).__name__,
+                previous_implementation=type(old_impl).__name__,
+                is_simulated=new_simulated,
+                was_simulated=old_simulated,
+            )
+            with self._lock:
+                self._interfaces[interface] = record
+                self._emit(event)
+
+        return handler
+
+    # ------------------------------------------------------------------
+    # Status queries
+    # ------------------------------------------------------------------
+
+    def get_status(self, interface: str) -> Optional[StatusRecord]:
+        """Get the current status of a single interface."""
+        with self._lock:
+            return self._interfaces.get(interface)
+
+    def get_all(self) -> Dict[str, StatusRecord]:
+        """Get all tracked interfaces and their status."""
+        with self._lock:
+            return dict(self._interfaces)
+
+    def is_any_simulated(self) -> bool:
+        """True if any tracked interface is running on a simulated implementation."""
+        with self._lock:
+            return any(r.is_simulated for r in self._interfaces.values())
+
+    def is_all_simulated(self) -> bool:
+        """True if all tracked interfaces are running on simulated implementations."""
+        with self._lock:
+            return bool(self._interfaces) and all(
+                r.is_simulated for r in self._interfaces.values()
+            )
+
+    def summary(self) -> Dict[str, Any]:
+        """Return a summary map suitable for JSON serialization or display.
+
+        Returns a string-keyed map with: tracker name (string), total
+        interfaces (integer), simulated count (integer), live count
+        (integer), and per-interface details.
+        """
+        with self._lock:
+            records = dict(self._interfaces)
+        simulated = sum(1 for r in records.values() if r.is_simulated)
+        return {
+            "tracker": self.name,
+            "total": len(records),
+            "simulated": simulated,
+            "live": len(records) - simulated,
+            "interfaces": {
+                name: {
+                    "implementation": r.implementation,
+                    "is_simulated": r.is_simulated,
+                    "timestamp": r.timestamp,
+                }
+                for name, r in records.items()
+            },
+        }
+
+    # ------------------------------------------------------------------
+    # Listeners
+    # ------------------------------------------------------------------
+
+    def add_listener(self, listener: StatusListener) -> None:
+        """Register a listener that receives StatusEvent objects."""
+        with self._lock:
+            self._listeners.append(listener)
+
+    def remove_listener(self, listener: StatusListener) -> None:
+        """Remove a previously registered listener."""
+        with self._lock:
+            self._listeners = [l for l in self._listeners if l is not listener]
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _emit(self, event: StatusEvent) -> None:
+        """Emit an event to all registered listeners. Called under lock."""
+        for listener in self._listeners:
+            try:
+                listener(event)
+            except Exception:
+                logger.exception("SimulationStatus listener error for event: %s", event.message)
+
+    @staticmethod
+    def _log_listener(event: StatusEvent) -> None:
+        """Default listener that logs all events."""
+        if event.change == StatusChange.SWAPPED:
+            if event.was_simulated != event.is_simulated:
+                logger.warning("SIMULATION STATUS: %s", event.message)
+            else:
+                logger.info("SIMULATION STATUS: %s", event.message)
+        else:
+            logger.info("SIMULATION STATUS: %s", event.message)

--- a/simulation/layer0/__init__.py
+++ b/simulation/layer0/__init__.py
@@ -1,0 +1,17 @@
+"""Layer 0: Hardware primitive simulators (no external runtime dependencies)."""
+
+from simulation.layer0.sensor import MockSensor, MockSensorArray
+from simulation.layer0.gpio   import MockGPIO
+from simulation.layer0.i2c    import MockI2C
+from simulation.layer0.spi    import MockSPI
+from simulation.layer0.camera import MockCamera
+from simulation.layer0.audio  import MockMicrophone, MockSpeaker
+
+__all__ = [
+    "MockSensor", "MockSensorArray",
+    "MockGPIO",
+    "MockI2C",
+    "MockSPI",
+    "MockCamera",
+    "MockMicrophone", "MockSpeaker",
+]

--- a/simulation/layer0/audio.py
+++ b/simulation/layer0/audio.py
@@ -1,0 +1,157 @@
+"""
+Layer 0: Audio device simulators.
+
+MockMicrophone generates synthetic sine-wave audio frames (PCM bytes).
+MockSpeaker is a null sink that accepts and discards audio data.
+
+No external runtime dependencies (pure Python math; no pyaudio, sounddevice, etc.).
+"""
+
+import math
+import struct
+import time
+import logging
+from typing import List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+from simulation.hal.device import MicrophoneInterface, SpeakerInterface
+
+
+class MockMicrophone(MicrophoneInterface):
+    """
+    Synthetic audio source that generates sine-wave PCM (Pulse-Code Modulation)
+    frames.
+
+    Implements :class:`~simulation.hal.device.MicrophoneInterface`.
+
+    Each ``read()`` call returns a ``bytes`` object containing 16-bit signed PCM
+    samples at the configured sample rate and frequency.
+
+    Example::
+
+        mic = MockMicrophone(sample_rate=16000, channels=1, chunk_size=1024)
+        mic.start()
+        frame = mic.read()   # bytes of length chunk_size * 2 (16-bit samples)
+        mic.stop()
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = 16_000,
+        channels: int = 1,
+        chunk_size: int = 1024,
+        frequency_hz: float = 440.0,   # A4 — audible sine wave
+        amplitude: float = 0.3,         # 0.0–1.0; 0.3 avoids clipping
+    ):
+        self.sample_rate  = sample_rate
+        self.channels     = channels
+        self.chunk_size   = chunk_size
+        self.frequency_hz = frequency_hz
+        self.amplitude    = amplitude
+        self._running     = False
+        self._sample_idx  = 0
+        logger.info("MockMicrophone initialized (%dHz, %dch, chunk=%d)",
+                    sample_rate, channels, chunk_size)
+
+    def start(self):
+        self._running    = True
+        self._sample_idx = 0
+        logger.debug("MockMicrophone started")
+
+    def stop(self):
+        self._running = False
+        logger.debug("MockMicrophone stopped")
+
+    def read(self) -> bytes:
+        """
+        Return one chunk of synthetic PCM audio (16-bit signed, little-endian).
+
+        Raises RuntimeError if not started.
+        """
+        if not self._running:
+            raise RuntimeError("Call start() before read()")
+
+        samples: List[int] = []
+        two_pi_f_over_sr = 2.0 * math.pi * self.frequency_hz / self.sample_rate
+        max_val = 32767  # 2^15 - 1
+
+        for _ in range(self.chunk_size):
+            # One sample per channel (channels share same sine phase for simplicity)
+            value = self.amplitude * math.sin(two_pi_f_over_sr * self._sample_idx)
+            sample = int(value * max_val)
+            for _ in range(self.channels):
+                samples.append(sample)
+            self._sample_idx += 1
+
+        return struct.pack(f"<{len(samples)}h", *samples)
+
+    @property
+    def bytes_per_chunk(self) -> int:
+        """Number of bytes returned by each read() call."""
+        return self.chunk_size * self.channels * 2  # 16-bit = 2 bytes per sample
+
+    def __repr__(self):
+        return (f"MockMicrophone(sample_rate={self.sample_rate}, "
+                f"channels={self.channels}, chunk_size={self.chunk_size})")
+
+
+class MockSpeaker(SpeakerInterface):
+    """
+    Null-sink audio output that accepts and discards PCM (Pulse-Code Modulation)
+    data.
+
+    Implements :class:`~simulation.hal.device.SpeakerInterface`.
+
+    Useful as a drop-in replacement for real audio output in tests and
+    headless environments.
+
+    Example::
+
+        speaker = MockSpeaker(sample_rate=16000)
+        speaker.start()
+        speaker.write(pcm_bytes)
+        speaker.stop()
+    """
+
+    def __init__(
+        self,
+        sample_rate: int = 16_000,
+        channels: int = 1,
+    ):
+        self.sample_rate  = sample_rate
+        self.channels     = channels
+        self._running     = False
+        self.bytes_written = 0
+        logger.info("MockSpeaker (null sink) initialized (%dHz, %dch)",
+                    sample_rate, channels)
+
+    def start(self):
+        self._running   = True
+        self.bytes_written = 0
+        logger.debug("MockSpeaker started")
+
+    def stop(self):
+        self._running = False
+        logger.debug("MockSpeaker stopped (%d bytes discarded)", self.bytes_written)
+
+    def write(self, data: bytes) -> int:
+        """Discard audio data; return number of bytes 'written'."""
+        if not self._running:
+            raise RuntimeError("Call start() before write()")
+        self.bytes_written += len(data)
+        return len(data)
+
+    def play_tone(self, frequency_hz: float = 440.0, duration_sec: float = 0.5):
+        """Simulate playing a tone (generates and discards PCM; no actual audio)."""
+        if not self._running:
+            raise RuntimeError("Call start() before play_tone()")
+        n_samples = int(self.sample_rate * duration_sec)
+        fake_bytes = n_samples * self.channels * 2
+        self.bytes_written += fake_bytes
+        logger.debug("MockSpeaker: discarded %.1f sec at %.1fHz (%d bytes)",
+                     duration_sec, frequency_hz, fake_bytes)
+
+    def __repr__(self):
+        return f"MockSpeaker(sample_rate={self.sample_rate}, channels={self.channels})"

--- a/simulation/layer0/camera.py
+++ b/simulation/layer0/camera.py
@@ -1,0 +1,102 @@
+"""
+Layer 0: Camera metadata simulator.
+
+Returns metadata dicts rather than actual image data.
+No external runtime dependencies (numpy not required for this module).
+"""
+
+import time
+import random
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+from simulation.hal.device import CameraInterface
+
+
+class MockCamera(CameraInterface):
+    """
+    Mock camera that returns metadata dicts instead of pixel data.
+
+    Implements :class:`~simulation.hal.device.CameraInterface`.
+
+    Each ``capture()`` call returns a dict with the same keys a real camera
+    driver would provide (frame number, timestamp, resolution, simulated
+    statistics). The ``data`` field is a descriptive placeholder string.
+
+    Example::
+
+        with MockCamera(device_id=0, width=1920, height=1080, fps=30) as cam:
+            frame = cam.capture()
+            print(frame["frame_number"], frame["brightness"])
+    """
+
+    def __init__(
+        self,
+        device_id: int = 0,
+        width: int = 1920,
+        height: int = 1080,
+        fps: int = 30,
+    ):
+        self.device_id   = device_id
+        self.width       = width
+        self.height      = height
+        self.fps         = fps
+        self.frame_count = 0
+        self.is_open     = True
+        self.start_time  = time.time()
+        logger.info("MockCamera initialized (device %d, %dx%d @ %dfps)",
+                    device_id, width, height, fps)
+
+    def capture(self) -> Dict[str, Any]:
+        """Return a simulated frame metadata dict."""
+        if not self.is_open:
+            raise RuntimeError("Camera is not open")
+        self.frame_count += 1
+        now = time.time()
+        return {
+            "frame_number": self.frame_count,
+            "timestamp":    now,
+            "elapsed_time": now - self.start_time,
+            "width":        self.width,
+            "height":       self.height,
+            "device_id":    self.device_id,
+            "fps":          self.fps,
+            "brightness":   round(random.uniform(0.3, 0.8), 3),
+            "contrast":     round(random.uniform(0.5, 1.0), 3),
+            "data":         f"<simulated_frame_{self.frame_count}>",
+        }
+
+    def set_resolution(self, width: int, height: int):
+        self.width  = width
+        self.height = height
+
+    def set_fps(self, fps: int):
+        self.fps = fps
+
+    def get_properties(self) -> Dict[str, Any]:
+        return {
+            "device_id":   self.device_id,
+            "width":       self.width,
+            "height":      self.height,
+            "fps":         self.fps,
+            "is_open":     self.is_open,
+            "frame_count": self.frame_count,
+        }
+
+    def release(self):
+        self.is_open = False
+        logger.info("MockCamera released (device %d, %d frames captured)",
+                    self.device_id, self.frame_count)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.release()
+
+    def __repr__(self):
+        return (f"MockCamera(device_id={self.device_id}, "
+                f"{self.width}x{self.height} @ {self.fps}fps)")

--- a/simulation/layer0/gpio.py
+++ b/simulation/layer0/gpio.py
@@ -1,0 +1,140 @@
+"""
+Layer 0: GPIO pin simulator.
+
+API-compatible with RPi.GPIO (class-method interface).
+No external runtime dependencies.
+"""
+
+import logging
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+from simulation.hal.device import GPIOInterface
+
+
+class MockGPIO(GPIOInterface):
+    """
+    Mock GPIO (General-Purpose Input/Output) interface that mirrors the
+    RPi.GPIO class-method API.
+
+    Implements :class:`~simulation.hal.device.GPIOInterface` via class methods
+    for RPi.GPIO drop-in compatibility.
+
+    Example::
+
+        MockGPIO.setmode(MockGPIO.BCM)
+        MockGPIO.setup(17, MockGPIO.OUT)
+        MockGPIO.output(17, MockGPIO.HIGH)
+        value = MockGPIO.input(17)
+        MockGPIO.cleanup()
+    """
+
+    # Pin numbering modes
+    BCM   = "BCM"
+    BOARD = "BOARD"
+
+    # Pin values
+    LOW  = 0
+    HIGH = 1
+
+    # Pin directions
+    IN  = "in"
+    OUT = "out"
+
+    # Pull resistor modes
+    PUD_OFF  = 0
+    PUD_DOWN = 1
+    PUD_UP   = 2
+
+    # Edge detection
+    RISING  = "rising"
+    FALLING = "falling"
+    BOTH    = "both"
+
+    # Class-level state (mirrors RPi.GPIO module-level globals)
+    _mode: Optional[str] = None
+    _pins: Dict[int, Dict] = {}
+    _warnings: bool = True
+
+    @classmethod
+    def setmode(cls, mode: str):
+        if mode not in (cls.BCM, cls.BOARD):
+            raise ValueError("Mode must be BCM or BOARD")
+        cls._mode = mode
+        logger.debug("GPIO mode set to %s", mode)
+
+    @classmethod
+    def getmode(cls) -> Optional[str]:
+        return cls._mode
+
+    @classmethod
+    def setwarnings(cls, enabled: bool):
+        cls._warnings = enabled
+
+    @classmethod
+    def setup(cls, pin: int, mode: str, pull_up_down: int = PUD_OFF,
+              initial: Optional[int] = None):
+        if cls._mode is None:
+            raise RuntimeError("Call setmode() before setup()")
+        if mode not in (cls.IN, cls.OUT):
+            raise ValueError("Mode must be IN or OUT")
+        cls._pins[pin] = {
+            "mode":          mode,
+            "value":         initial if initial is not None else cls.LOW,
+            "pull":          pull_up_down,
+            "edge_callback": None,
+            "edge_type":     None,
+        }
+        logger.debug("GPIO pin %d configured as %s", pin, mode.upper())
+
+    @classmethod
+    def output(cls, pin: int, value: int):
+        if pin not in cls._pins:
+            raise RuntimeError(f"Pin {pin} not set up")
+        if cls._pins[pin]["mode"] != cls.OUT:
+            raise RuntimeError(f"Pin {pin} is not configured as output")
+        old = cls._pins[pin]["value"]
+        cls._pins[pin]["value"] = value
+        logger.debug("GPIO pin %d -> %d", pin, value)
+        # Trigger edge detection
+        cb = cls._pins[pin].get("edge_callback")
+        if cb and old != value:
+            cb(pin)
+
+    @classmethod
+    def input(cls, pin: int) -> int:
+        if pin not in cls._pins:
+            raise RuntimeError(f"Pin {pin} not set up")
+        return cls._pins[pin]["value"]
+
+    @classmethod
+    def add_event_detect(cls, pin: int, edge: str, callback=None, bouncetime: int = 0):
+        if pin not in cls._pins:
+            raise RuntimeError(f"Pin {pin} not set up")
+        cls._pins[pin]["edge_callback"] = callback
+        cls._pins[pin]["edge_type"]     = edge
+
+    @classmethod
+    def remove_event_detect(cls, pin: int):
+        if pin in cls._pins:
+            cls._pins[pin]["edge_callback"] = None
+
+    @classmethod
+    def cleanup(cls, pin: Optional[int] = None):
+        if pin is None:
+            cls._pins.clear()
+            cls._mode = None
+            logger.debug("All GPIO pins cleaned up")
+        elif pin in cls._pins:
+            del cls._pins[pin]
+            logger.debug("GPIO pin %d cleaned up", pin)
+
+    @classmethod
+    def get_pin_state(cls, pin: int) -> Optional[Dict]:
+        return cls._pins.get(pin)
+
+    @classmethod
+    def get_all_pins(cls) -> Dict:
+        return dict(cls._pins)

--- a/simulation/layer0/i2c.py
+++ b/simulation/layer0/i2c.py
@@ -1,0 +1,85 @@
+"""
+Layer 0: I2C bus simulator.
+
+Register-array-backed: each device address gets a 256-byte register bank.
+No external runtime dependencies.
+"""
+
+import logging
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+from simulation.hal.device import I2CInterface
+
+
+class MockI2C(I2CInterface):
+    """
+    Mock I2C (Inter-Integrated Circuit) bus that simulates register read/write
+    operations.
+
+    Implements :class:`~simulation.hal.device.I2CInterface`.
+
+    Each device address is backed by a 256-byte register array.
+    Unwritten registers return 0x00.
+
+    Example::
+
+        bus = MockI2C(bus_number=1)
+        bus.write_byte_data(0x68, 0x6B, 0x00)   # wake MPU-6050
+        whoami = bus.read_byte_data(0x68, 0x75)  # read WHO_AM_I register
+    """
+
+    def __init__(self, bus_number: int = 1):
+        self.bus_number = bus_number
+        self.devices: Dict[int, bytearray] = {}
+        logger.info("MockI2C bus %d initialized", bus_number)
+
+    def _ensure_device(self, addr: int):
+        if addr not in self.devices:
+            self.devices[addr] = bytearray(256)
+
+    def write_byte_data(self, addr: int, register: int, value: int):
+        """Write one byte to a device register."""
+        self._ensure_device(addr)
+        self.devices[addr][register] = value & 0xFF
+        logger.debug("I2C write: addr=0x%02X reg=0x%02X val=0x%02X", addr, register, value)
+
+    def read_byte_data(self, addr: int, register: int) -> int:
+        """Read one byte from a device register."""
+        self._ensure_device(addr)
+        value = self.devices[addr][register]
+        logger.debug("I2C read:  addr=0x%02X reg=0x%02X val=0x%02X", addr, register, value)
+        return value
+
+    def write_i2c_block_data(self, addr: int, register: int, data: List[int]):
+        """Write a block of bytes starting at register."""
+        self._ensure_device(addr)
+        for i, byte in enumerate(data):
+            self.devices[addr][(register + i) & 0xFF] = byte & 0xFF
+        logger.debug("I2C block write: addr=0x%02X reg=0x%02X len=%d", addr, register, len(data))
+
+    def read_i2c_block_data(self, addr: int, register: int, length: int) -> List[int]:
+        """Read a block of bytes starting at register."""
+        self._ensure_device(addr)
+        data = [self.devices[addr][(register + i) & 0xFF] for i in range(length)]
+        logger.debug("I2C block read:  addr=0x%02X reg=0x%02X len=%d", addr, register, length)
+        return data
+
+    def write_byte(self, addr: int, value: int):
+        """Write a single byte (no register address)."""
+        self._ensure_device(addr)
+        self.devices[addr][0] = value & 0xFF
+
+    def read_byte(self, addr: int) -> int:
+        """Read a single byte (no register address)."""
+        self._ensure_device(addr)
+        return self.devices[addr][0]
+
+    def close(self):
+        """Release the bus (no-op in simulation)."""
+        logger.info("MockI2C bus %d closed", self.bus_number)
+
+    def __repr__(self):
+        return f"MockI2C(bus_number={self.bus_number}, devices={[hex(a) for a in self.devices]})"

--- a/simulation/layer0/sensor.py
+++ b/simulation/layer0/sensor.py
@@ -1,0 +1,291 @@
+"""
+Layer 0: Sensor value generators for O.A.S.I.S. simulation.
+
+Provides sensor data matching the field names and formats expected by O.A.S.I.S. components.
+No external runtime dependencies beyond the standard library and numpy.
+
+Sensor types and their MQTT device names:
+  "motion"       -> device: "Motion", format: "Orientation" (heading/pitch/roll + quaternion)
+  "gps"          -> device: "GPS" (time/date/fix/latitude/longitude/speed/altitude/satellites)
+  "environmental"-> device: "Enviro" (temp/humidity/air_quality/tvoc_ppb/eco2_ppm/co2_ppm/heat_index_c/dew_point)
+"""
+
+import math
+import time
+import random
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+from simulation.hal.device import SensorInterface, SensorArrayInterface
+
+
+class MockSensor(SensorInterface):
+    """
+    Generic mock sensor that generates time-varying values.
+
+    Implements :class:`~simulation.hal.device.SensorInterface`.
+
+    Sensor type selects which fields are produced. Use ``sensor_type`` matching the
+    O.A.S.I.S. MQTT device type your component expects (e.g. "motion", "gps",
+    "environmental", "temperature", "humidity").
+
+    Example::
+
+        sensor = MockSensor("imu", sensor_type="motion")
+        reading = sensor.read()
+        # {"device": "Motion", "format": "Orientation", "heading": 45.2, ...}
+    """
+
+    def __init__(
+        self,
+        name: str = "sensor",
+        sensor_type: str = "generic",
+        update_interval: float = 0.0,
+    ):
+        self.name = name
+        self.sensor_type = sensor_type
+        self.update_interval = update_interval
+        self.reading_count = 0
+        self.last_reading_time: float = 0.0
+        self.is_active = True
+
+        # Adjustable base values (set via calibrate())
+        self._base_temperature: float = 22.5
+        self._base_humidity: float = 65.0
+        self._base_pressure: float = 1013.25
+        self._base_heading: float = 0.0      # degrees, 0-360
+        self._base_pitch: float = 0.0        # degrees
+        self._base_roll: float = 0.0         # degrees
+        self._base_lat: float = 33.7490      # Atlanta, GA
+        self._base_lon: float = -84.3880
+
+        # Phase offset for sine-wave variation (gives each sensor a unique starting point)
+        self._phase = random.uniform(0, 2 * math.pi)
+
+        logger.info("MockSensor '%s' initialized (type: %s)", name, sensor_type)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def read(self) -> Dict[str, Any]:
+        """Return a sensor reading dict. Blocks until update_interval has elapsed."""
+        if not self.is_active:
+            raise RuntimeError(f"Sensor '{self.name}' is not active")
+
+        now = time.time()
+        elapsed_since_last = now - self.last_reading_time
+        if elapsed_since_last < self.update_interval:
+            time.sleep(self.update_interval - elapsed_since_last)
+            now = time.time()
+
+        self.reading_count += 1
+        self.last_reading_time = now
+
+        readers = {
+            "motion":        self._read_motion,
+            "gps":           self._read_gps,
+            "environmental": self._read_environmental,
+            "temperature":   self._read_temperature,
+            "humidity":      self._read_humidity,
+            "pressure":      self._read_pressure,
+        }
+        reader = readers.get(self.sensor_type, self._read_generic)
+        return reader(now)
+
+    def calibrate(self, **kwargs):
+        """Override base values used for simulated readings."""
+        for key, value in kwargs.items():
+            attr = f"_base_{key}"
+            if hasattr(self, attr):
+                setattr(self, attr, value)
+                logger.info("Calibrated %s.%s = %s", self.name, key, value)
+
+    def activate(self):
+        self.is_active = True
+
+    def deactivate(self):
+        self.is_active = False
+
+    def reset(self):
+        self.reading_count = 0
+        self.last_reading_time = 0.0
+
+    def __repr__(self):
+        return f"MockSensor(name={self.name!r}, type={self.sensor_type!r})"
+
+    # ------------------------------------------------------------------
+    # Sensor-specific readers — output matches O.A.S.I.S. MQTT schemas
+    # ------------------------------------------------------------------
+
+    def _sine(self, t: float, period: float = 60.0, amplitude: float = 1.0) -> float:
+        """Smooth sine-wave variation with this sensor's phase offset."""
+        return amplitude * math.sin(2 * math.pi * t / period + self._phase)
+
+    def _read_motion(self, t: float) -> Dict[str, Any]:
+        """
+        Output matches MIRAGE command_processing.c Motion/Orientation schema::
+
+            {"device": "Motion", "format": "Orientation",
+             "heading": 45.2, "pitch": -2.1, "roll": 3.5}
+
+        Also includes quaternion fields for full OCP compliance.
+        """
+        heading = (self._base_heading + self._sine(t, period=120, amplitude=45)) % 360
+        pitch   = self._base_pitch + self._sine(t, period=30,  amplitude=5)
+        roll    = self._base_roll  + self._sine(t, period=20,  amplitude=3)
+
+        # Euler → quaternion (approximate, small-angle is fine for simulation)
+        h_r = math.radians(heading / 2)
+        p_r = math.radians(pitch   / 2)
+        r_r = math.radians(roll    / 2)
+        return {
+            "device": "Motion",
+            "format": "Orientation",
+            "heading": round(heading, 2),
+            "pitch":   round(pitch,   2),
+            "roll":    round(roll,    2),
+            # Quaternion (w, x, y, z) — OCP extended fields
+            "w": round(math.cos(h_r) * math.cos(p_r) * math.cos(r_r)
+                       + math.sin(h_r) * math.sin(p_r) * math.sin(r_r), 4),
+            "x": round(math.cos(h_r) * math.cos(p_r) * math.sin(r_r)
+                       - math.sin(h_r) * math.sin(p_r) * math.cos(r_r), 4),
+            "y": round(math.cos(h_r) * math.sin(p_r) * math.cos(r_r)
+                       + math.sin(h_r) * math.cos(p_r) * math.sin(r_r), 4),
+            "z": round(math.sin(h_r) * math.cos(p_r) * math.cos(r_r)
+                       - math.cos(h_r) * math.sin(p_r) * math.sin(r_r), 4),
+        }
+
+    def _read_gps(self, t: float) -> Dict[str, Any]:
+        """
+        Output matches MIRAGE command_processing.c GPS schema::
+
+            {"device": "GPS", "time": "12:30:00", "date": "2026-03-07",
+             "fix": 1, "latitude": 37.77, "latitudeDegrees": 37.77, "lat": "N",
+             "longitude": -122.42, "longitudeDegrees": -122.42, "lon": "W",
+             "speed": 0.0, "angle": 0.0, "altitude": 50.0, "satellites": 8}
+        """
+        from datetime import datetime, timezone
+        now_dt = datetime.now(timezone.utc)
+        lat = self._base_lat + self._sine(t, period=300, amplitude=0.001)
+        lon = self._base_lon + self._sine(t, period=240, amplitude=0.001)
+        return {
+            "device":           "GPS",
+            "time":             now_dt.strftime("%H:%M:%S"),
+            "date":             now_dt.strftime("%Y-%m-%d"),
+            "fix":              1,
+            "quality":          1,
+            "latitude":         round(lat, 6),
+            "latitudeDegrees":  round(lat, 6),
+            "lat":              "N" if lat >= 0 else "S",
+            "longitude":        round(lon, 6),
+            "longitudeDegrees": round(lon, 6),
+            "lon":              "W" if lon < 0 else "E",
+            "speed":            round(max(0, self._sine(t, period=90, amplitude=0.5)), 2),
+            "angle":            round((self._base_heading + self._sine(t, period=120, amplitude=45)) % 360, 1),
+            "altitude":         round(320 + self._sine(t, period=60, amplitude=2), 1),
+            "satellites":       8,
+        }
+
+    def _read_environmental(self, t: float) -> Dict[str, Any]:
+        """
+        Output matches MIRAGE command_processing.c Enviro schema::
+
+            {"device": "Enviro", "temp": 22.5, "humidity": 65.0,
+             "air_quality": 85.0, "tvoc_ppb": 12.0, "eco2_ppm": 400.0,
+             "co2_ppm": 415.0, "heat_index_c": 24.0, "dew_point": 14.5}
+        """
+        temp     = self._base_temperature + self._sine(t, period=120, amplitude=2)
+        humidity = max(10, min(100, self._base_humidity + self._sine(t, period=90, amplitude=5)))
+        # Approximate heat index (Steadman formula, simplified)
+        hi = temp + 0.33 * (humidity / 100 * 6.105 * math.exp(17.27 * temp / (237.7 + temp))) - 4.0
+        # Approximate dew point (Magnus formula)
+        dp = (243.04 * (math.log(humidity / 100) + 17.625 * temp / (243.04 + temp))
+              / (17.625 - math.log(humidity / 100) - 17.625 * temp / (243.04 + temp)))
+        tvoc  = max(0, 10 + self._sine(t, period=45, amplitude=8))
+        eco2  = max(400, 400 + self._sine(t, period=60, amplitude=50))
+        co2   = eco2 + random.uniform(5, 20)
+        aq    = max(0, min(100, 85 + self._sine(t, period=180, amplitude=10)))
+        return {
+            "device":      "Enviro",
+            "temp":        round(temp, 1),
+            "humidity":    round(humidity, 1),
+            "air_quality": round(aq, 1),
+            "tvoc_ppb":    round(tvoc, 1),
+            "eco2_ppm":    round(eco2, 1),
+            "co2_ppm":     round(co2, 1),
+            "heat_index_c": round(hi, 1),
+            "dew_point":   round(dp, 1),
+        }
+
+    def _read_temperature(self, t: float) -> Dict[str, Any]:
+        return {
+            "temperature": round(self._base_temperature + self._sine(t, period=120, amplitude=2), 1),
+            "unit": "celsius",
+        }
+
+    def _read_humidity(self, t: float) -> Dict[str, Any]:
+        return {
+            "humidity": round(max(0, min(100,
+                self._base_humidity + self._sine(t, period=90, amplitude=5))), 1),
+            "unit": "percent",
+        }
+
+    def _read_pressure(self, t: float) -> Dict[str, Any]:
+        return {
+            "pressure": round(self._base_pressure + self._sine(t, period=180, amplitude=5), 2),
+            "unit": "hPa",
+        }
+
+    def _read_generic(self, t: float) -> Dict[str, Any]:
+        return {
+            "value":  round(50 + self._sine(t, period=60, amplitude=25), 2),
+            "status": "ok",
+        }
+
+
+class MockSensorArray(SensorArrayInterface):
+    """
+    A collection of MockSensor instances for multi-sensor simulations.
+
+    Implements :class:`~simulation.hal.device.SensorArrayInterface`.
+
+    Example::
+
+        sensors = MockSensorArray()
+        sensors.add_sensor("imu",   "motion")
+        sensors.add_sensor("gps",   "gps")
+        sensors.add_sensor("enviro","environmental")
+        readings = sensors.read_all()
+    """
+
+    def __init__(self):
+        self.sensors: Dict[str, MockSensor] = {}
+
+    def add_sensor(self, name: str, sensor_type: str = "generic") -> MockSensor:
+        sensor = MockSensor(name=name, sensor_type=sensor_type)
+        self.sensors[name] = sensor
+        return sensor
+
+    def remove_sensor(self, name: str):
+        self.sensors.pop(name, None)
+
+    def read_all(self) -> Dict[str, Dict[str, Any]]:
+        return {name: sensor.read() for name, sensor in self.sensors.items()}
+
+    def read_sensor(self, name: str) -> Dict[str, Any]:
+        if name not in self.sensors:
+            raise KeyError(f"Sensor '{name}' not found")
+        return self.sensors[name].read()
+
+    def get_sensor(self, name: str) -> Optional[MockSensor]:
+        return self.sensors.get(name)
+
+    def list_sensors(self):
+        return list(self.sensors.keys())
+
+    def __repr__(self):
+        return f"MockSensorArray(sensors={self.list_sensors()!r})"

--- a/simulation/layer0/spi.py
+++ b/simulation/layer0/spi.py
@@ -1,0 +1,112 @@
+"""
+Layer 0: SPI bus simulator.
+
+Loopback simulation by default; supports pluggable response handlers.
+No external runtime dependencies.
+"""
+
+import logging
+from typing import Callable, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+from simulation.hal.device import SPIInterface
+
+
+class MockSPI(SPIInterface):
+    """
+    Mock SPI (Serial Peripheral Interface) that simulates SPI communication.
+
+    Implements :class:`~simulation.hal.device.SPIInterface`.
+
+    Default behaviour is loopback (echoes sent bytes back).
+    Provide a ``response_handler`` callable to simulate device-specific responses.
+
+    Example::
+
+        spi = MockSPI(bus=0, device=0)
+        response = spi.transfer([0x01, 0x02, 0x03])
+        spi.close()
+
+    Custom response::
+
+        def my_device(data):
+            if data[0] == 0xD0:        # read ID register
+                return [0x60] + [0] * (len(data) - 1)
+            return [0x00] * len(data)
+
+        spi = MockSPI(bus=0, device=0, response_handler=my_device)
+    """
+
+    MODE_0 = 0  # CPOL=0, CPHA=0
+    MODE_1 = 1  # CPOL=0, CPHA=1
+    MODE_2 = 2  # CPOL=1, CPHA=0
+    MODE_3 = 3  # CPOL=1, CPHA=1
+
+    def __init__(
+        self,
+        bus: int = 0,
+        device: int = 0,
+        max_speed_hz: int = 500_000,
+        mode: int = 0,
+        bits_per_word: int = 8,
+        response_handler: Optional[Callable[[List[int]], List[int]]] = None,
+    ):
+        self.bus            = bus
+        self.device         = device
+        self.max_speed_hz   = max_speed_hz
+        self.mode           = mode
+        self.bits_per_word  = bits_per_word
+        self._response_handler = response_handler
+        self.is_open        = True
+        self.transfer_count = 0
+        logger.info("MockSPI initialized (bus %d, device %d, %d Hz, mode %d)",
+                    bus, device, max_speed_hz, mode)
+
+    def transfer(self, data: List[int]) -> List[int]:
+        """Transfer data; return simulated response (loopback by default)."""
+        if not self.is_open:
+            raise RuntimeError("SPI device is not open")
+        self.transfer_count += 1
+        if self._response_handler:
+            response = self._response_handler(data)
+        else:
+            # Simple loopback — echo back
+            response = list(data)
+        logger.debug("SPI transfer #%d: tx=%s rx=%s",
+                     self.transfer_count,
+                     [hex(x) for x in data],
+                     [hex(x) for x in response])
+        return response
+
+    def read(self, length: int) -> List[int]:
+        """Read ``length`` bytes (sends zeros)."""
+        return self.transfer([0x00] * length)
+
+    def write(self, data: List[int]):
+        """Write data (discard response)."""
+        self.transfer(data)
+
+    def set_speed(self, speed_hz: int):
+        self.max_speed_hz = speed_hz
+
+    def set_mode(self, mode: int):
+        if mode not in (0, 1, 2, 3):
+            raise ValueError("SPI mode must be 0-3")
+        self.mode = mode
+
+    def close(self):
+        self.is_open = False
+        logger.info("MockSPI closed (bus %d, device %d, %d transfers)",
+                    self.bus, self.device, self.transfer_count)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+    def __repr__(self):
+        return (f"MockSPI(bus={self.bus}, device={self.device}, "
+                f"{self.max_speed_hz}Hz, mode={self.mode})")

--- a/simulation/layer1/__init__.py
+++ b/simulation/layer1/__init__.py
@@ -1,0 +1,8 @@
+"""
+Layer 1: Protocol simulators (requires paho-mqtt, websockets).
+
+Install extras:
+    pip install "oasis-simulation[layer1]"
+or:
+    pip install paho-mqtt websockets
+"""

--- a/simulation/layer2/__init__.py
+++ b/simulation/layer2/__init__.py
@@ -1,0 +1,8 @@
+"""
+Layer 2: Software behavior simulators (requires flask; optional LLM/memory deps).
+
+Install extras:
+    pip install "oasis-simulation[layer2]"
+or:
+    pip install flask
+"""

--- a/tests/test_layer0.py
+++ b/tests/test_layer0.py
@@ -1,0 +1,266 @@
+"""
+Layer 0 sanity checks.
+
+These tests verify that all Layer 0 simulators:
+  - Import without errors
+  - Return the expected dict keys
+  - Behave correctly under basic operations
+
+No external dependencies are required to run these tests.
+"""
+
+import pytest
+from simulation.layer0.sensor import MockSensor, MockSensorArray
+from simulation.layer0.gpio   import MockGPIO
+from simulation.layer0.i2c    import MockI2C
+from simulation.layer0.spi    import MockSPI
+from simulation.layer0.camera import MockCamera
+from simulation.layer0.audio  import MockMicrophone, MockSpeaker
+
+
+# ------------------------------------------------------------------
+# MockSensor
+# ------------------------------------------------------------------
+
+class TestMockSensorMotion:
+    def setup_method(self):
+        self.sensor = MockSensor("imu", sensor_type="motion")
+
+    def test_read_returns_dict(self):
+        data = self.sensor.read()
+        assert isinstance(data, dict)
+
+    def test_motion_has_required_keys(self):
+        data = self.sensor.read()
+        for key in ("device", "format", "heading", "pitch", "roll"):
+            assert key in data, f"Missing key: {key}"
+
+    def test_motion_device_name(self):
+        assert self.sensor.read()["device"] == "Motion"
+
+    def test_motion_format_name(self):
+        assert self.sensor.read()["format"] == "Orientation"
+
+    def test_heading_range(self):
+        for _ in range(10):
+            h = self.sensor.read()["heading"]
+            assert 0 <= h < 360, f"Heading out of range: {h}"
+
+    def test_quaternion_fields(self):
+        data = self.sensor.read()
+        for key in ("w", "x", "y", "z"):
+            assert key in data
+
+
+class TestMockSensorGPS:
+    def setup_method(self):
+        self.sensor = MockSensor("gps", sensor_type="gps")
+
+    def test_gps_has_required_keys(self):
+        data = self.sensor.read()
+        for key in ("device", "time", "date", "fix", "latitude", "longitude",
+                    "latitudeDegrees", "longitudeDegrees", "lat", "lon",
+                    "speed", "altitude", "satellites"):
+            assert key in data, f"Missing key: {key}"
+
+    def test_gps_device_name(self):
+        assert self.sensor.read()["device"] == "GPS"
+
+    def test_fix_is_integer(self):
+        assert isinstance(self.sensor.read()["fix"], int)
+
+
+class TestMockSensorEnvironmental:
+    def setup_method(self):
+        self.sensor = MockSensor("enviro", sensor_type="environmental")
+
+    def test_enviro_has_required_keys(self):
+        data = self.sensor.read()
+        for key in ("device", "temp", "humidity", "air_quality",
+                    "tvoc_ppb", "eco2_ppm", "co2_ppm", "heat_index_c", "dew_point"):
+            assert key in data, f"Missing key: {key}"
+
+    def test_enviro_device_name(self):
+        assert self.sensor.read()["device"] == "Enviro"
+
+    def test_humidity_range(self):
+        for _ in range(10):
+            h = self.sensor.read()["humidity"]
+            assert 0 <= h <= 100, f"Humidity out of range: {h}"
+
+
+class TestMockSensorArray:
+    def test_add_and_read_all(self):
+        arr = MockSensorArray()
+        arr.add_sensor("imu",    "motion")
+        arr.add_sensor("enviro", "environmental")
+        results = arr.read_all()
+        assert "imu" in results
+        assert "enviro" in results
+
+    def test_remove_sensor(self):
+        arr = MockSensorArray()
+        arr.add_sensor("imu", "motion")
+        arr.remove_sensor("imu")
+        assert "imu" not in arr.read_all()
+
+
+# ------------------------------------------------------------------
+# MockGPIO
+# ------------------------------------------------------------------
+
+class TestMockGPIO:
+    def setup_method(self):
+        MockGPIO.cleanup()
+
+    def test_setmode_bcm(self):
+        MockGPIO.setmode(MockGPIO.BCM)
+        assert MockGPIO.getmode() == MockGPIO.BCM
+
+    def test_setup_and_output(self):
+        MockGPIO.setmode(MockGPIO.BCM)
+        MockGPIO.setup(17, MockGPIO.OUT)
+        MockGPIO.output(17, MockGPIO.HIGH)
+        assert MockGPIO.input(17) == MockGPIO.HIGH
+
+    def test_input_default_low(self):
+        MockGPIO.setmode(MockGPIO.BCM)
+        MockGPIO.setup(18, MockGPIO.OUT)
+        assert MockGPIO.input(18) == MockGPIO.LOW
+
+    def test_cleanup_clears_pins(self):
+        MockGPIO.setmode(MockGPIO.BCM)
+        MockGPIO.setup(17, MockGPIO.OUT)
+        MockGPIO.cleanup()
+        assert MockGPIO.get_all_pins() == {}
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError):
+            MockGPIO.setmode("INVALID")
+
+
+# ------------------------------------------------------------------
+# MockI2C
+# ------------------------------------------------------------------
+
+class TestMockI2C:
+    def setup_method(self):
+        self.bus = MockI2C(bus_number=1)
+
+    def test_write_and_read_byte(self):
+        self.bus.write_byte_data(0x68, 0x6B, 0xAB)
+        assert self.bus.read_byte_data(0x68, 0x6B) == 0xAB
+
+    def test_unwritten_register_returns_zero(self):
+        assert self.bus.read_byte_data(0x48, 0x00) == 0x00
+
+    def test_block_write_and_read(self):
+        self.bus.write_i2c_block_data(0x68, 0x3B, [0x01, 0x02, 0x03])
+        data = self.bus.read_i2c_block_data(0x68, 0x3B, 3)
+        assert data == [0x01, 0x02, 0x03]
+
+    def test_multiple_devices_independent(self):
+        self.bus.write_byte_data(0x10, 0x00, 0xAA)
+        self.bus.write_byte_data(0x20, 0x00, 0xBB)
+        assert self.bus.read_byte_data(0x10, 0x00) == 0xAA
+        assert self.bus.read_byte_data(0x20, 0x00) == 0xBB
+
+
+# ------------------------------------------------------------------
+# MockSPI
+# ------------------------------------------------------------------
+
+class TestMockSPI:
+    def test_loopback_default(self):
+        with MockSPI(bus=0, device=0) as spi:
+            result = spi.transfer([0x01, 0x02, 0x03])
+            assert result == [0x01, 0x02, 0x03]
+
+    def test_custom_response_handler(self):
+        def handler(data):
+            return [0xFF] * len(data)
+
+        spi = MockSPI(response_handler=handler)
+        assert spi.transfer([0x00, 0x00]) == [0xFF, 0xFF]
+        spi.close()
+
+    def test_closed_raises(self):
+        spi = MockSPI()
+        spi.close()
+        with pytest.raises(RuntimeError):
+            spi.transfer([0x01])
+
+    def test_read_returns_zeros_by_default(self):
+        with MockSPI() as spi:
+            # loopback of zeros is zeros
+            result = spi.read(4)
+            assert result == [0x00, 0x00, 0x00, 0x00]
+
+
+# ------------------------------------------------------------------
+# MockCamera
+# ------------------------------------------------------------------
+
+class TestMockCamera:
+    def test_capture_returns_dict(self):
+        with MockCamera() as cam:
+            frame = cam.capture()
+            assert isinstance(frame, dict)
+
+    def test_capture_increments_frame_number(self):
+        with MockCamera() as cam:
+            f1 = cam.capture()
+            f2 = cam.capture()
+            assert f2["frame_number"] == f1["frame_number"] + 1
+
+    def test_capture_has_dimensions(self):
+        with MockCamera(width=1280, height=720) as cam:
+            frame = cam.capture()
+            assert frame["width"] == 1280
+            assert frame["height"] == 720
+
+    def test_released_camera_raises(self):
+        cam = MockCamera()
+        cam.release()
+        with pytest.raises(RuntimeError):
+            cam.capture()
+
+
+# ------------------------------------------------------------------
+# MockMicrophone / MockSpeaker
+# ------------------------------------------------------------------
+
+class TestMockMicrophone:
+    def test_read_returns_bytes(self):
+        mic = MockMicrophone(sample_rate=16_000, chunk_size=512)
+        mic.start()
+        data = mic.read()
+        mic.stop()
+        assert isinstance(data, bytes)
+
+    def test_read_length_correct(self):
+        mic = MockMicrophone(sample_rate=16_000, channels=1, chunk_size=256)
+        mic.start()
+        data = mic.read()
+        mic.stop()
+        # 256 samples * 1 channel * 2 bytes/sample (16-bit)
+        assert len(data) == 256 * 1 * 2
+
+    def test_read_without_start_raises(self):
+        mic = MockMicrophone()
+        with pytest.raises(RuntimeError):
+            mic.read()
+
+
+class TestMockSpeaker:
+    def test_write_returns_byte_count(self):
+        speaker = MockSpeaker()
+        speaker.start()
+        n = speaker.write(b"\x00" * 1024)
+        speaker.stop()
+        assert n == 1024
+
+    def test_write_without_start_raises(self):
+        speaker = MockSpeaker()
+        with pytest.raises(RuntimeError):
+            speaker.write(b"\x00")

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,0 +1,231 @@
+"""Tests for the Provider — runtime hot-swap wrapper for HAL interfaces."""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from simulation.hal.provider import Provider
+from simulation.layer0.camera import MockCamera
+from simulation.layer0.sensor import MockSensor
+from simulation.layer0.gpio import MockGPIO
+
+
+class TestProviderBasic:
+    """Provider wraps an implementation and forwards attribute access."""
+
+    def test_forwards_method_calls(self):
+        sensor = MockSensor("imu", sensor_type="motion")
+        provider = Provider(sensor)
+        data = provider.read()
+        assert "heading" in data
+
+    def test_forwards_properties(self):
+        sensor = MockSensor("imu", sensor_type="motion")
+        provider = Provider(sensor)
+        assert provider.name == "imu"
+        assert provider.sensor_type == "motion"
+
+    def test_implementation_property(self):
+        sensor = MockSensor("imu")
+        provider = Provider(sensor)
+        assert provider.implementation is sensor
+
+    def test_implementation_type(self):
+        sensor = MockSensor("imu")
+        provider = Provider(sensor)
+        assert provider.implementation_type is MockSensor
+
+    def test_repr(self):
+        sensor = MockSensor("imu", sensor_type="motion")
+        provider = Provider(sensor)
+        assert "Provider" in repr(provider)
+        assert "MockSensor" in repr(provider)
+
+
+class TestProviderSwap:
+    """Provider.swap() replaces the active implementation at runtime."""
+
+    def test_swap_changes_implementation(self):
+        cam1 = MockCamera(device_id=0, width=640, height=480)
+        cam2 = MockCamera(device_id=1, width=1920, height=1080)
+        provider = Provider(cam1)
+        assert provider.width == 640
+
+        old = provider.swap(cam2)
+        assert old is cam1
+        assert provider.width == 1920
+        assert provider.implementation is cam2
+
+    def test_swap_returns_old_implementation(self):
+        sensor1 = MockSensor("a")
+        sensor2 = MockSensor("b")
+        provider = Provider(sensor1)
+        old = provider.swap(sensor2)
+        assert old is sensor1
+
+    def test_swap_callback_called(self):
+        calls = []
+
+        def on_swap(old, new):
+            calls.append((type(old).__name__, type(new).__name__))
+
+        cam1 = MockCamera(device_id=0)
+        cam2 = MockCamera(device_id=1)
+        provider = Provider(cam1, on_swap=on_swap)
+        provider.swap(cam2)
+
+        assert len(calls) == 1
+        assert calls[0] == ("MockCamera", "MockCamera")
+
+    def test_swap_callback_receives_correct_instances(self):
+        received = {}
+
+        def on_swap(old, new):
+            received["old"] = old
+            received["new"] = new
+
+        sensor1 = MockSensor("a")
+        sensor2 = MockSensor("b")
+        provider = Provider(sensor1, on_swap=on_swap)
+        provider.swap(sensor2)
+
+        assert received["old"] is sensor1
+        assert received["new"] is sensor2
+
+    def test_multiple_swaps(self):
+        s1 = MockSensor("a")
+        s2 = MockSensor("b")
+        s3 = MockSensor("c")
+        provider = Provider(s1)
+
+        provider.swap(s2)
+        assert provider.name == "b"
+
+        provider.swap(s3)
+        assert provider.name == "c"
+
+    def test_swap_back_to_mock(self):
+        """Simulate graceful degradation: real → mock fallback."""
+        mock = MockCamera(device_id=0, width=640, height=480)
+        real = MockCamera(device_id=1, width=1920, height=1080)  # stand-in for real camera
+
+        provider = Provider(mock)
+        assert provider.width == 640
+
+        # "Real camera connected"
+        provider.swap(real)
+        assert provider.width == 1920
+
+        # "Real camera disconnected — fall back to mock"
+        provider.swap(mock)
+        assert provider.width == 640
+
+    def test_no_callback_when_none(self):
+        """swap() works without a callback."""
+        provider = Provider(MockSensor("a"))
+        provider.swap(MockSensor("b"))
+        assert provider.name == "b"
+
+
+class TestProviderThreadSafety:
+    """Provider is safe to use from multiple threads."""
+
+    def test_concurrent_reads(self):
+        sensor = MockSensor("imu", sensor_type="motion")
+        provider = Provider(sensor)
+        results = []
+        errors = []
+
+        def read_loop():
+            try:
+                for _ in range(50):
+                    data = provider.read()
+                    results.append(data)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=read_loop) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+        assert len(results) == 200
+
+    def test_concurrent_swap_and_read(self):
+        """Swap and read simultaneously without crashing."""
+        mock1 = MockSensor("a", sensor_type="motion")
+        mock2 = MockSensor("b", sensor_type="gps")
+        provider = Provider(mock1)
+        errors = []
+
+        def swap_loop():
+            try:
+                for i in range(50):
+                    if i % 2 == 0:
+                        provider.swap(mock2)
+                    else:
+                        provider.swap(mock1)
+            except Exception as e:
+                errors.append(e)
+
+        def read_loop():
+            try:
+                for _ in range(50):
+                    provider.read()
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=swap_loop)
+        t2 = threading.Thread(target=read_loop)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert len(errors) == 0
+
+
+class TestProviderGracefulDegradation:
+    """Demonstrate the graceful degradation pattern from ADR-0003 Amendment 4."""
+
+    def test_camera_hotplug_scenario(self):
+        """USB camera plugged in → swap to real; unplugged → fall back to mock."""
+        swap_log = []
+
+        def on_swap(old, new):
+            swap_log.append(f"{type(old).__name__}→{type(new).__name__}")
+
+        mock_cam = MockCamera(device_id=0, width=640, height=480)
+        provider = Provider(mock_cam, on_swap=on_swap)
+
+        # Initial state: mock camera
+        frame = provider.capture()
+        assert frame["width"] == 640
+
+        # Event: USB camera connected
+        real_cam = MockCamera(device_id=1, width=1920, height=1080)  # stand-in
+        provider.swap(real_cam)
+        frame = provider.capture()
+        assert frame["width"] == 1920
+
+        # Event: USB camera disconnected
+        provider.swap(mock_cam)
+        frame = provider.capture()
+        assert frame["width"] == 640
+
+        assert swap_log == ["MockCamera→MockCamera", "MockCamera→MockCamera"]
+
+    def test_sensor_failover_scenario(self):
+        """Real sensor fails → fall back to mock sensor transparently."""
+        mock_sensor = MockSensor("imu", sensor_type="motion")
+        provider = Provider(mock_sensor)
+
+        # Component reads sensor — doesn't care if it's real or mock
+        data = provider.read()
+        assert "heading" in data
+        assert "pitch" in data
+        assert "roll" in data

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,320 @@
+"""Tests for SimulationStatus — centralized simulation vs. real tracking."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from simulation.hal.status import (
+    SimulationStatus,
+    StatusChange,
+    StatusEvent,
+    StatusRecord,
+    is_mock_implementation,
+)
+from simulation.hal.provider import Provider
+from simulation.layer0.camera import MockCamera
+from simulation.layer0.sensor import MockSensor
+
+
+class TestIsMockImplementation:
+    """is_mock_implementation() heuristic detection."""
+
+    def test_mock_class_detected(self):
+        assert is_mock_implementation(MockCamera()) is True
+
+    def test_mock_sensor_detected(self):
+        assert is_mock_implementation(MockSensor("imu")) is True
+
+    def test_non_mock_by_name(self):
+        class RealCamera:
+            pass
+        assert is_mock_implementation(RealCamera()) is False
+
+    def test_override_attribute(self):
+        class CustomImpl:
+            _is_simulated = True
+        assert is_mock_implementation(CustomImpl()) is True
+
+    def test_override_attribute_false(self):
+        class MockLike:
+            _is_simulated = False
+        assert is_mock_implementation(MockLike()) is False
+
+
+class TestStatusEvent:
+    """StatusEvent message generation and serialization."""
+
+    def test_registered_message(self):
+        event = StatusEvent(
+            change=StatusChange.REGISTERED,
+            interface="camera",
+            implementation="MockCamera",
+            previous_implementation=None,
+            is_simulated=True,
+            was_simulated=None,
+        )
+        assert "registered" in event.message
+        assert "simulated" in event.message
+        assert "camera" in event.message
+
+    def test_swapped_mode_change_message(self):
+        event = StatusEvent(
+            change=StatusChange.SWAPPED,
+            interface="camera",
+            implementation="RealCamera",
+            previous_implementation="MockCamera",
+            is_simulated=False,
+            was_simulated=True,
+        )
+        assert "switched" in event.message
+        assert "simulated" in event.message
+        assert "live" in event.message
+
+    def test_swapped_same_mode_message(self):
+        event = StatusEvent(
+            change=StatusChange.SWAPPED,
+            interface="camera",
+            implementation="MockCameraV2",
+            previous_implementation="MockCamera",
+            is_simulated=True,
+            was_simulated=True,
+        )
+        assert "swapped implementation" in event.message
+
+    def test_to_dict(self):
+        event = StatusEvent(
+            change=StatusChange.REGISTERED,
+            interface="sensor.imu",
+            implementation="MockSensor",
+            previous_implementation=None,
+            is_simulated=True,
+            was_simulated=None,
+        )
+        d = event.to_dict()
+        assert d["change"] == "registered"
+        assert d["interface"] == "sensor.imu"
+        assert d["is_simulated"] is True
+        assert "message" in d
+        # Verify it's JSON serializable
+        json.dumps(d)
+
+
+class TestSimulationStatus:
+    """SimulationStatus tracker core functionality."""
+
+    def test_register_interface(self):
+        tracker = SimulationStatus("test")
+        tracker.register("camera", MockCamera())
+        status = tracker.get_status("camera")
+        assert status is not None
+        assert status.is_simulated is True
+        assert status.implementation == "MockCamera"
+
+    def test_register_emits_event(self):
+        events = []
+        tracker = SimulationStatus("test")
+        tracker.add_listener(lambda e: events.append(e))
+        tracker.register("camera", MockCamera())
+        assert len(events) == 1
+        assert events[0].change == StatusChange.REGISTERED
+
+    def test_unregister(self):
+        tracker = SimulationStatus("test")
+        tracker.register("camera", MockCamera())
+        tracker.unregister("camera")
+        assert tracker.get_status("camera") is None
+
+    def test_unregister_emits_event(self):
+        events = []
+        tracker = SimulationStatus("test")
+        tracker.add_listener(lambda e: events.append(e))
+        tracker.register("camera", MockCamera())
+        tracker.unregister("camera")
+        assert events[-1].change == StatusChange.UNREGISTERED
+
+    def test_get_all(self):
+        tracker = SimulationStatus("test")
+        tracker.register("camera", MockCamera())
+        tracker.register("sensor", MockSensor("imu"))
+        all_status = tracker.get_all()
+        assert len(all_status) == 2
+        assert "camera" in all_status
+        assert "sensor" in all_status
+
+    def test_is_any_simulated(self):
+        tracker = SimulationStatus("test")
+        tracker.register("camera", MockCamera())
+        assert tracker.is_any_simulated() is True
+
+    def test_is_all_simulated(self):
+        tracker = SimulationStatus("test")
+        tracker.register("camera", MockCamera())
+        tracker.register("sensor", MockSensor("imu"))
+        assert tracker.is_all_simulated() is True
+
+    def test_summary(self):
+        tracker = SimulationStatus("mirage")
+        tracker.register("camera", MockCamera())
+        tracker.register("sensor", MockSensor("imu"))
+        s = tracker.summary()
+        assert s["tracker"] == "mirage"
+        assert s["total"] == 2
+        assert s["simulated"] == 2
+        assert s["live"] == 0
+        assert "camera" in s["interfaces"]
+        # Verify JSON serializable
+        json.dumps(s)
+
+
+class TestProviderIntegration:
+    """SimulationStatus integrated with Provider via create_swap_handler."""
+
+    def test_swap_handler_emits_event(self):
+        events = []
+        tracker = SimulationStatus("test")
+        tracker.add_listener(lambda e: events.append(e))
+
+        handler = tracker.create_swap_handler("camera")
+        camera = Provider(MockCamera(), on_swap=handler)
+        tracker.register("camera", camera.implementation)
+
+        # Swap to a different mock
+        camera.swap(MockCamera(device_id=1))
+
+        swap_events = [e for e in events if e.change == StatusChange.SWAPPED]
+        assert len(swap_events) == 1
+        assert swap_events[0].interface == "camera"
+
+    def test_swap_handler_updates_tracker(self):
+        tracker = SimulationStatus("test")
+        handler = tracker.create_swap_handler("camera")
+        camera = Provider(MockCamera(device_id=0, width=640), on_swap=handler)
+        tracker.register("camera", camera.implementation)
+
+        camera.swap(MockCamera(device_id=1, width=1920))
+        status = tracker.get_status("camera")
+        assert status.implementation == "MockCamera"
+
+    def test_mode_change_detection(self):
+        """Detect when an interface switches between simulated and live."""
+        events = []
+        tracker = SimulationStatus("test")
+        tracker.add_listener(lambda e: events.append(e))
+
+        handler = tracker.create_swap_handler("camera")
+        camera = Provider(MockCamera(), on_swap=handler)
+        tracker.register("camera", camera.implementation)
+
+        # Simulate "real camera connected" — use a non-Mock class
+        class RealCamera:
+            _is_simulated = False
+            def capture(self): return {}
+            def set_resolution(self, w, h): pass
+            def set_fps(self, f): pass
+            def get_properties(self): return {}
+            def release(self): pass
+
+        camera.swap(RealCamera())
+        swap_event = [e for e in events if e.change == StatusChange.SWAPPED][0]
+        assert swap_event.was_simulated is True
+        assert swap_event.is_simulated is False
+        assert "switched" in swap_event.message
+        assert "live" in swap_event.message
+
+    def test_graceful_degradation_scenario(self):
+        """Full hot-plug scenario: mock → real → mock (camera disconnect)."""
+        events = []
+        tracker = SimulationStatus("mirage")
+        tracker.add_listener(lambda e: events.append(e))
+
+        handler = tracker.create_swap_handler("camera")
+        mock_cam = MockCamera(device_id=0)
+        camera = Provider(mock_cam, on_swap=handler)
+        tracker.register("camera", mock_cam)
+
+        # Real camera connected
+        class RealCamera:
+            _is_simulated = False
+            def capture(self): return {}
+            def set_resolution(self, w, h): pass
+            def set_fps(self, f): pass
+            def get_properties(self): return {}
+            def release(self): pass
+
+        camera.swap(RealCamera())
+        assert not tracker.is_all_simulated()
+
+        # Real camera disconnected — fall back to mock
+        camera.swap(mock_cam)
+        assert tracker.is_all_simulated()
+
+        # Verify event sequence
+        swap_events = [e for e in events if e.change == StatusChange.SWAPPED]
+        assert len(swap_events) == 2
+        assert swap_events[0].message.count("live") > 0  # mock → real
+        assert swap_events[1].message.count("simulated") > 0  # real → mock
+
+    def test_multiple_interfaces(self):
+        """Track multiple interfaces independently."""
+        tracker = SimulationStatus("mirage")
+
+        cam_handler = tracker.create_swap_handler("camera")
+        sensor_handler = tracker.create_swap_handler("sensor.imu")
+
+        camera = Provider(MockCamera(), on_swap=cam_handler)
+        sensor = Provider(MockSensor("imu", sensor_type="motion"), on_swap=sensor_handler)
+
+        tracker.register("camera", camera.implementation)
+        tracker.register("sensor.imu", sensor.implementation)
+
+        assert tracker.is_all_simulated()
+        s = tracker.summary()
+        assert s["simulated"] == 2
+        assert s["live"] == 0
+
+
+class TestNotificationChannels:
+    """Verify that multiple listeners can be registered for different channels."""
+
+    def test_multiple_listeners(self):
+        log_events = []
+        mqtt_events = []
+
+        tracker = SimulationStatus("test")
+        tracker.add_listener(lambda e: log_events.append(e.message))
+        tracker.add_listener(lambda e: mqtt_events.append(e.to_dict()))
+
+        tracker.register("camera", MockCamera())
+
+        assert len(log_events) == 1
+        assert len(mqtt_events) == 1
+        assert isinstance(mqtt_events[0], dict)
+
+    def test_remove_listener(self):
+        events = []
+        listener = lambda e: events.append(e)
+
+        tracker = SimulationStatus("test")
+        tracker.add_listener(listener)
+        tracker.register("a", MockCamera())
+        assert len(events) == 1
+
+        tracker.remove_listener(listener)
+        tracker.register("b", MockSensor("x"))
+        assert len(events) == 1  # no new events
+
+    def test_listener_error_does_not_break_others(self):
+        """A failing listener should not prevent other listeners from firing."""
+        good_events = []
+
+        def bad_listener(event):
+            raise RuntimeError("intentional error")
+
+        tracker = SimulationStatus("test")
+        tracker.add_listener(bad_listener)
+        tracker.add_listener(lambda e: good_events.append(e))
+
+        tracker.register("camera", MockCamera())
+        assert len(good_events) == 1  # good listener still received the event


### PR DESCRIPTION
## Summary
Add Layer 0 (Device) — hardware primitive mocks with no external runtime dependencies:

- `MockSensor` / `MockSensorArray` — motion (heading/pitch/roll/quaternion), GPS (lat/lon/alt/fix/satellites), environmental (temp/humidity/air quality/CO2)
- `MockGPIO` — RPi.GPIO-compatible class-method API
- `MockI2C` — 256-byte register array per device address
- `MockSPI` — loopback with pluggable response handlers
- `MockCamera` — frame metadata dict output (no pixel data)
- `MockMicrophone` / `MockSpeaker` — synthetic PCM frames, null sink

Also includes README.md, CONTRIBUTING.md, FOUNDATION_NOTICE.md, LICENSE (GPL-3.0), .gitignore, pyproject.toml (pip-installable with optional dep groups), and test suite.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Refactoring

## Testing
- [x] `pytest tests/test_layer0.py` — all Device layer classes covered
- [x] Layer 0 imports succeed with no external deps beyond stdlib

## Checklist
- [x] Tests added (tests/test_layer0.py)
- [x] Documentation updated (README.md, CONTRIBUTING.md)
- [x] No breaking changes

**Stacked on**: PR #7 (docker)
Closes #8
Parent tracker: #1

---
🤖 Generated with [Claude Code](https://claude.ai/code)