### PR TITLE
Add Network layer — OCP peers, DAP2 satellite, MQTT helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,8 +227,6 @@ speaker.stop()
 
 ### Network Layer — Protocol Simulation
 
-> Network layer is under active development. See `simulation/layer1/` for current status.
-
 Enables testing of O.A.S.I.S. protocol interactions without live hardware:
 
 - **`mqtt.py`** — MQTT topic publisher/subscriber helpers with message serializers
@@ -273,7 +271,7 @@ cd simulation_framework && pip install -e .
 | Layer | Status |
 |-------|--------|
 | Device — Hardware primitives | **Available** |
-| Network — Protocol simulation | In development |
+| Network — Protocol simulation | **Available** |
 | Platform — Service simulation | In development |
 
 ## Contributing

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -122,3 +122,70 @@ Null-sink audio output.
 |-----------|------|---------|-------------|
 | `sample_rate` | integer | `16000` | Samples per second |
 | `channels` | integer | `1` | Audio channels |
+
+---
+
+## Network Layer — `simulation.layer1`
+
+### `simulation.hal.network` — Interface Contracts
+
+| Interface | Methods | Description |
+|-----------|---------|-------------|
+| `TopicBuilderInterface` | `status()`, `discovery(capability)`, `command()`, `broadcast()`, `peer_status(peer_id)`, `sim_discovery()` | MQTT (Message Queuing Telemetry Transport) topic string construction |
+| `MessageSerializerInterface` | `status_online(...)`, `status_offline()`, `discovery(elements)`, `command(...)`, `response(...)` | OCP (OASIS Communications Protocol) message serialization to JSON |
+| `OCPPeerInterface` | `set_lwt()`, `start()`, `stop()`, `is_running` | OCP peer lifecycle |
+| `DAP2SatelliteInterface` | `connect()`, `disconnect()`, `query(text)`, `is_connected` | DAP2 (Dawn Audio Protocol 2.0) satellite client |
+| `DAP2DaemonInterface` | `start()`, `stop()` | DAP2 mock server |
+
+### `TopicBuilder(TopicBuilderInterface)`
+
+Builds MQTT topic strings per OCP conventions.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `component` | string | Component name (e.g., `"mirage"` → `"hud"`, `"dawn"` → `"dawn"`) |
+
+### `MessageSerializer(MessageSerializerInterface)`
+
+Serializes OCP messages to JSON strings.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `device` | string | Device name included in message payloads |
+
+### `OCPPeer(OCPPeerInterface)`
+
+Simulated OCP peer with status, discovery, and heartbeat.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `client` | paho MQTT client | (required) | Connected MQTT client |
+| `peer_id` | string | (required) | Unique peer identifier |
+| `component` | string | (required) | O.A.S.I.S. component name |
+| `embodiment` | `Embodiment` | `E4` | `Embodiment.E3` (physical) or `Embodiment.E4` (software) |
+| `capabilities` | list of strings | `[]` | Advertised in discovery messages |
+| `version` | string | `"0.0.0-sim"` | Version in status messages |
+| `heartbeat_interval` | float | `30.0` | Seconds between heartbeat publishes |
+
+### `DAP2Satellite(DAP2SatelliteInterface)`
+
+WebSocket client for DAP2 satellite protocol.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `uri` | string | `"ws://localhost:3000"` | D.A.W.N. daemon WebSocket URI |
+| `name` | string | `"Mock Satellite"` | Satellite display name |
+| `location` | string | `"simulation"` | Room or location identifier |
+| `ping_interval` | float | `10.0` | Seconds between keepalive pings |
+
+`query(text)` returns a `StreamResponse` with: `stream_id` (integer), `text` (assembled response string), `reason` (string), `states` (list of state maps).
+
+### `DAP2MockDaemon(DAP2DaemonInterface)`
+
+Standalone DAP2 mock server for testing without D.A.W.N.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `host` | string | `"localhost"` | Bind address |
+| `port` | integer | `3000` | Bind port |
+| `query_handler` | callable or None | echo handler | `(text: str) -> str` response generator |

--- a/simulation/hal/network.py
+++ b/simulation/hal/network.py
@@ -1,0 +1,172 @@
+"""
+Network layer interface contracts — protocol participation abstractions.
+
+These ABCs (Abstract Base Classes) define the API that both Python mock
+implementations (Layer 1) and future protocol test harnesses must conform to.
+
+- TopicBuilderInterface: MQTT (Message Queuing Telemetry Transport) topic
+  construction for OCP (OASIS Communications Protocol) conventions
+- MessageSerializerInterface: OCP message serialization to JSON
+- OCPPeerInterface: OCP peer lifecycle (status, discovery, heartbeat)
+- DAP2SatelliteInterface: DAP2 (Dawn Audio Protocol 2.0) satellite client
+- DAP2DaemonInterface: DAP2 mock server for testing without a real D.A.W.N. instance
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# MQTT topic helpers
+# ---------------------------------------------------------------------------
+
+
+class TopicBuilderInterface(ABC):
+    """Interface for constructing MQTT topic strings per OCP conventions."""
+
+    @abstractmethod
+    def status(self) -> str:
+        """Return the component status topic (e.g., ``hud/status``)."""
+        ...
+
+    @abstractmethod
+    def discovery(self, capability: Optional[str] = None) -> str:
+        """Return the discovery topic, optionally scoped to a capability."""
+        ...
+
+    @abstractmethod
+    def command(self) -> str:
+        """Return the primary command topic."""
+        ...
+
+    @abstractmethod
+    def broadcast(self) -> str:
+        """Return the system-wide broadcast topic."""
+        ...
+
+    @abstractmethod
+    def peer_status(self, peer_id: str) -> str:
+        """Return the per-peer status topic for OCP embodiment tracking."""
+        ...
+
+    @abstractmethod
+    def sim_discovery(self) -> str:
+        """Return the simulation discovery topic for simulated peers."""
+        ...
+
+
+class MessageSerializerInterface(ABC):
+    """Interface for serializing OCP messages to JSON strings."""
+
+    @abstractmethod
+    def status_online(self, version: str = "0.0.0",
+                      capabilities: Optional[List[str]] = None) -> str:
+        """Serialize an online status message."""
+        ...
+
+    @abstractmethod
+    def status_offline(self) -> str:
+        """Serialize an offline status message (timestamp=0 for LWT)."""
+        ...
+
+    @abstractmethod
+    def discovery(self, elements: List[str]) -> str:
+        """Serialize a discovery message."""
+        ...
+
+    @abstractmethod
+    def command(self, action: str, value: str = "",
+                request_id: Optional[str] = None, **extra: Any) -> str:
+        """Serialize a command/request message."""
+        ...
+
+    @abstractmethod
+    def response(self, action: str = "completed", value: str = "",
+                 request_id: Optional[str] = None,
+                 status: str = "success", **extra: Any) -> str:
+        """Serialize a command response message."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# OCP peer
+# ---------------------------------------------------------------------------
+
+
+class OCPPeerInterface(ABC):
+    """Interface for an OCP peer that publishes status and keepalive over MQTT.
+
+    Peers follow the OCP lifecycle:
+    1. Set LWT (Last Will and Testament) before connecting
+    2. Publish online status (retained)
+    3. Publish discovery message (retained)
+    4. Heartbeat every N seconds
+    5. On shutdown, publish offline status and disconnect
+    """
+
+    @abstractmethod
+    def set_lwt(self) -> None:
+        """Set the MQTT LWT (Last Will and Testament) for offline detection."""
+        ...
+
+    @abstractmethod
+    def start(self) -> None:
+        """Publish online status and discovery, start heartbeat loop."""
+        ...
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Publish offline status and stop heartbeat."""
+        ...
+
+    @property
+    @abstractmethod
+    def is_running(self) -> bool:
+        """Whether the peer is actively publishing heartbeats."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# DAP2 satellite and daemon
+# ---------------------------------------------------------------------------
+
+
+class DAP2SatelliteInterface(ABC):
+    """Interface for a DAP2 satellite client that connects to a D.A.W.N. daemon."""
+
+    @abstractmethod
+    async def connect(self) -> Dict[str, Any]:
+        """Connect and register with the daemon.  Returns the registration ack."""
+        ...
+
+    @abstractmethod
+    async def disconnect(self) -> None:
+        """Gracefully disconnect."""
+        ...
+
+    @abstractmethod
+    async def query(self, text: str) -> Any:
+        """Send a text query and collect the full streaming response."""
+        ...
+
+    @property
+    @abstractmethod
+    def is_connected(self) -> bool:
+        """Whether the satellite is registered and connected."""
+        ...
+
+
+class DAP2DaemonInterface(ABC):
+    """Interface for a DAP2 mock server."""
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Start accepting satellite connections."""
+        ...
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Stop the server."""
+        ...

--- a/simulation/layer1/__init__.py
+++ b/simulation/layer1/__init__.py
@@ -5,4 +5,9 @@ Install extras:
     pip install "oasis-simulation[layer1]"
 or:
     pip install paho-mqtt websockets
+
+Modules:
+    mqtt         — MQTT topic builders and OCP message serializers
+    ocp          — OCP peer simulation (E3/E4 embodiment, status, keepalive)
+    dap2_client  — DAP2 satellite mock client and standalone mock daemon
 """

--- a/simulation/layer1/dap2_client.py
+++ b/simulation/layer1/dap2_client.py
@@ -1,0 +1,394 @@
+"""
+DAP2 satellite mock — a simulated Tier 1 satellite that connects to a DAWN
+daemon via WebSocket, registers, sends queries, and receives streaming responses.
+
+Can also run as a **standalone mock daemon** (via :class:`DAP2MockDaemon`) for
+testing without a real DAWN instance.
+
+Satellite example::
+
+    import asyncio
+    from simulation.layer1.dap2_client import DAP2Satellite
+
+    async def main():
+        sat = DAP2Satellite(
+            uri="ws://localhost:3000",
+            name="Kitchen Assistant",
+            location="kitchen",
+        )
+        await sat.connect()
+        response = await sat.query("turn on the kitchen lights")
+        print(response)  # full assembled response text
+        await sat.disconnect()
+
+    asyncio.run(main())
+
+Mock daemon example::
+
+    import asyncio
+    from simulation.layer1.dap2_client import DAP2MockDaemon
+
+    async def main():
+        daemon = DAP2MockDaemon(host="localhost", port=3000)
+        await daemon.start()
+        # ... satellites can now connect ...
+        await daemon.stop()
+
+    asyncio.run(main())
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+try:
+    import websockets
+    from websockets import connect as ws_connect, serve as ws_serve
+except ImportError as exc:
+    raise ImportError(
+        "Layer 1 requires websockets.  Install with:  "
+        'pip install "oasis-sim[layer1]"'
+    ) from exc
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SatelliteInfo:
+    """Registration payload for a DAP2 satellite."""
+
+    uuid: str = field(default_factory=lambda: str(uuid.uuid4()))
+    name: str = "Mock Satellite"
+    location: str = "simulation"
+    tier: int = 1
+    capabilities: dict[str, bool] = field(
+        default_factory=lambda: {
+            "local_asr": True,
+            "local_tts": True,
+            "wake_word": True,
+        }
+    )
+
+
+@dataclass
+class StreamResponse:
+    """Assembled response from a streaming DAP2 exchange."""
+
+    stream_id: int
+    text: str
+    reason: str  # "complete", "error", "cancelled"
+    states: list[dict[str, Any]] = field(default_factory=list)
+
+
+from simulation.hal.network import DAP2SatelliteInterface, DAP2DaemonInterface
+
+
+# ---------------------------------------------------------------------------
+# DAP2 Satellite (client)
+# ---------------------------------------------------------------------------
+
+
+class DAP2Satellite(DAP2SatelliteInterface):
+    """Simulated Tier 1 DAP2 (Dawn Audio Protocol 2.0) satellite that connects to a D.A.W.N. daemon.
+
+    Parameters
+    ----------
+    uri : str
+        WebSocket URI of the DAWN daemon (e.g., ``"ws://localhost:3000"``).
+    name : str
+        Human-readable satellite name.
+    location : str
+        Room or location identifier.
+    info : SatelliteInfo | None
+        Full registration info.  If ``None``, built from *name* and *location*.
+    ping_interval : float
+        Seconds between keepalive pings (default 10).
+    """
+
+    def __init__(
+        self,
+        uri: str = "ws://localhost:3000",
+        name: str = "Mock Satellite",
+        location: str = "simulation",
+        info: SatelliteInfo | None = None,
+        ping_interval: float = 10.0,
+    ) -> None:
+        self.uri = uri
+        self.info = info or SatelliteInfo(name=name, location=location)
+        self.ping_interval = ping_interval
+
+        self._ws: Any = None
+        self._session_id: int | None = None
+        self._reconnect_secret: str | None = None
+        self._ping_task: asyncio.Task[None] | None = None
+        self._registered = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> dict[str, Any]:
+        """Connect and register with the daemon.  Returns the registration ack payload."""
+        self._ws = await ws_connect(self.uri)
+        ack = await self._register()
+        self._ping_task = asyncio.create_task(self._ping_loop())
+        return ack
+
+    async def disconnect(self) -> None:
+        """Gracefully disconnect."""
+        if self._ping_task is not None:
+            self._ping_task.cancel()
+            try:
+                await self._ping_task
+            except asyncio.CancelledError:
+                pass
+            self._ping_task = None
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+        self._registered = False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._ws is not None and self._registered
+
+    # ------------------------------------------------------------------
+    # Messaging
+    # ------------------------------------------------------------------
+
+    async def query(self, text: str) -> StreamResponse:
+        """Send a text query and collect the full streaming response."""
+        if not self.is_connected:
+            raise RuntimeError("Not connected — call connect() first")
+        await self._send({
+            "type": "satellite_query",
+            "payload": {"text": text},
+        })
+        return await self._collect_stream()
+
+    async def send_raw(self, message: dict[str, Any]) -> None:
+        """Send an arbitrary JSON message."""
+        await self._send(message)
+
+    async def recv_raw(self) -> dict[str, Any]:
+        """Receive and parse a single JSON message."""
+        return await self._recv()
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    async def _register(self) -> dict[str, Any]:
+        await self._send({
+            "type": "satellite_register",
+            "payload": {
+                "uuid": self.info.uuid,
+                "name": self.info.name,
+                "location": self.info.location,
+                "tier": self.info.tier,
+                "capabilities": self.info.capabilities,
+            },
+        })
+        ack = await self._recv()
+        if ack.get("type") != "satellite_register_ack":
+            raise RuntimeError(f"Expected register_ack, got: {ack}")
+        payload = ack.get("payload", {})
+        if not payload.get("success", False):
+            raise RuntimeError(f"Registration failed: {payload.get('message', 'unknown')}")
+        self._session_id = payload.get("session_id")
+        self._reconnect_secret = payload.get("reconnect_secret")
+        self._registered = True
+        return payload
+
+    async def _collect_stream(self) -> StreamResponse:
+        """Read messages until ``stream_end``, assembling deltas."""
+        text_parts: list[str] = []
+        states: list[dict[str, Any]] = []
+        stream_id = 0
+
+        while True:
+            msg = await self._recv()
+            msg_type = msg.get("type", "")
+            payload = msg.get("payload", {})
+
+            if msg_type == "state":
+                states.append(payload)
+            elif msg_type == "stream_start":
+                stream_id = payload.get("stream_id", 0)
+            elif msg_type == "stream_delta":
+                text_parts.append(payload.get("delta", ""))
+            elif msg_type == "stream_end":
+                return StreamResponse(
+                    stream_id=stream_id,
+                    text="".join(text_parts),
+                    reason=payload.get("reason", "complete"),
+                    states=states,
+                )
+            elif msg_type == "error":
+                return StreamResponse(
+                    stream_id=stream_id,
+                    text="".join(text_parts),
+                    reason="error",
+                    states=states,
+                )
+
+    async def _ping_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self.ping_interval)
+                await self._send({"type": "satellite_ping"})
+                # Consume the pong (non-blocking drain)
+                try:
+                    msg = await asyncio.wait_for(self._recv(), timeout=5.0)
+                    # Silently discard pong
+                except asyncio.TimeoutError:
+                    pass
+        except asyncio.CancelledError:
+            raise
+
+    async def _send(self, data: dict[str, Any]) -> None:
+        await self._ws.send(json.dumps(data))
+
+    async def _recv(self) -> dict[str, Any]:
+        raw = await self._ws.recv()
+        return json.loads(raw)
+
+
+# ---------------------------------------------------------------------------
+# DAP2 Mock Daemon (server) — for testing without a real DAWN instance
+# ---------------------------------------------------------------------------
+
+
+class DAP2MockDaemon(DAP2DaemonInterface):
+    """A minimal DAP2 (Dawn Audio Protocol 2.0)-compatible WebSocket server for testing.
+
+    Responds to ``satellite_register`` with an ack, echoes queries back
+    as a streaming response, and replies to pings with pongs.
+
+    A custom *query_handler* can be provided to generate domain-specific
+    responses.
+
+    Parameters
+    ----------
+    host : str
+        Bind address (default ``"localhost"``).
+    port : int
+        Bind port (default ``3000``).
+    query_handler : callable | None
+        ``async def handler(text: str) -> str`` that returns the response
+        text for a given query.  If ``None``, the default echo handler is
+        used.
+    """
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 3000,
+        query_handler: Callable[[str], Any] | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.query_handler = query_handler or self._default_handler
+        self._server: Any = None
+        self._next_session_id = 1
+        self._next_stream_id = 1
+
+    async def start(self) -> None:
+        """Start the mock daemon."""
+        self._server = await ws_serve(self._handle_client, self.host, self.port)
+
+    async def stop(self) -> None:
+        """Stop the mock daemon."""
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _handle_client(self, ws: Any) -> None:
+        registered = False
+        try:
+            async for raw in ws:
+                msg = json.loads(raw)
+                msg_type = msg.get("type", "")
+
+                if msg_type == "satellite_register":
+                    session_id = self._next_session_id
+                    self._next_session_id += 1
+                    await ws.send(json.dumps({
+                        "type": "satellite_register_ack",
+                        "payload": {
+                            "success": True,
+                            "session_id": session_id,
+                            "reconnect_secret": f"secret-{session_id}",
+                            "message": f"Registered as {msg['payload'].get('name', 'unknown')}",
+                        },
+                    }))
+                    registered = True
+
+                elif msg_type == "satellite_query":
+                    if not registered:
+                        await ws.send(json.dumps({
+                            "type": "error",
+                            "payload": {
+                                "code": "NOT_REGISTERED",
+                                "message": "Must register before sending queries",
+                            },
+                        }))
+                        continue
+
+                    text = msg.get("payload", {}).get("text", "")
+
+                    # State: thinking
+                    await ws.send(json.dumps({
+                        "type": "state",
+                        "payload": {"state": "thinking", "detail": "Processing query..."},
+                    }))
+
+                    # Generate response
+                    if asyncio.iscoroutinefunction(self.query_handler):
+                        response_text = await self.query_handler(text)
+                    else:
+                        response_text = self.query_handler(text)
+
+                    # Stream the response
+                    stream_id = self._next_stream_id
+                    self._next_stream_id += 1
+                    await ws.send(json.dumps({
+                        "type": "stream_start",
+                        "payload": {"stream_id": stream_id},
+                    }))
+                    # Split response into sentence-level deltas
+                    sentences = [s.strip() + " " for s in response_text.split(". ") if s.strip()]
+                    if not sentences:
+                        sentences = [response_text]
+                    for sentence in sentences:
+                        await ws.send(json.dumps({
+                            "type": "stream_delta",
+                            "payload": {"stream_id": stream_id, "delta": sentence},
+                        }))
+                    await ws.send(json.dumps({
+                        "type": "stream_end",
+                        "payload": {"stream_id": stream_id, "reason": "complete"},
+                    }))
+
+                elif msg_type == "satellite_ping":
+                    import time
+                    await ws.send(json.dumps({
+                        "type": "satellite_pong",
+                        "payload": {"timestamp": int(time.time())},
+                    }))
+
+        except websockets.exceptions.ConnectionClosed:
+            pass
+
+    @staticmethod
+    def _default_handler(text: str) -> str:
+        """Default echo handler — returns the query text as the response."""
+        return f"Echo: {text}"

--- a/simulation/layer1/mqtt.py
+++ b/simulation/layer1/mqtt.py
@@ -1,0 +1,181 @@
+"""
+MQTT topic helpers — builders and serializers for O.A.S.I.S. message schemas.
+
+Provides convenience functions for constructing MQTT topics and serializing
+messages that follow the OCP (OASIS Communications Protocol) conventions.
+Component-specific payload schemas (e.g., MIRAGE's exact JSON format for the
+``aura`` topic) live in component demos, not here.
+
+Example::
+
+    from simulation.layer1.mqtt import TopicBuilder, MessageSerializer
+
+    tb = TopicBuilder("mirage")
+    tb.status()          # "hud/status"
+    tb.discovery("map")  # "hud/discovery/map"
+
+    ms = MessageSerializer("mirage")
+    ms.status_online(version="2.1.0", capabilities=["armor_display", "detect"])
+    ms.discovery(elements=["armor_display", "detect", "map", "info"])
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+# Mapping from component names to their OCP topic base.
+# Some components use abbreviated topic names per OCP convention.
+_TOPIC_BASE: dict[str, str] = {
+    "mirage": "hud",
+    "dawn": "dawn",
+    "aura": "aura",
+    "spark": "spark",
+    "stat": "stat",
+    "beacon": "beacon",
+    "genesis": "genesis",
+    "scope": "scope",
+}
+
+
+from simulation.hal.network import TopicBuilderInterface, MessageSerializerInterface
+
+
+class TopicBuilder(TopicBuilderInterface):
+    """Build MQTT (Message Queuing Telemetry Transport) topic strings for an O.A.S.I.S. component.
+
+    Parameters
+    ----------
+    component : str
+        Component name (e.g., ``"mirage"``, ``"dawn"``).  Looked up in the
+        OCP topic-base mapping; falls back to the component name itself.
+    """
+
+    def __init__(self, component: str) -> None:
+        self.component = component.lower()
+        self.base = _TOPIC_BASE.get(self.component, self.component)
+
+    def status(self) -> str:
+        """Component status topic (e.g., ``hud/status``)."""
+        return f"{self.base}/status"
+
+    def discovery(self, capability: str | None = None) -> str:
+        """Discovery topic, optionally scoped to a capability.
+
+        ``hud/discovery/#`` or ``hud/discovery/map``.
+        """
+        if capability:
+            return f"{self.base}/discovery/{capability}"
+        return f"{self.base}/discovery/#"
+
+    def command(self) -> str:
+        """Primary command topic (e.g., ``hud``, ``dawn``)."""
+        return self.base
+
+    def broadcast(self) -> str:
+        """System-wide broadcast topic."""
+        return "oasis/broadcast"
+
+    def peer_status(self, peer_id: str) -> str:
+        """Per-peer status topic for OCP embodiment (e.g., ``oasis/<peer_id>/status``)."""
+        return f"oasis/{peer_id}/status"
+
+    def sim_discovery(self) -> str:
+        """Simulation discovery topic for simulated peers."""
+        return "echo/discovery/simulates"
+
+
+class MessageSerializer(MessageSerializerInterface):
+    """Serialize O.A.S.I.S. OCP (OASIS Communications Protocol) messages to JSON strings.
+
+    Parameters
+    ----------
+    device : str
+        Device/component name included in message payloads.
+    """
+
+    def __init__(self, device: str) -> None:
+        self.device = device.lower()
+
+    def status_online(
+        self,
+        version: str = "0.0.0",
+        capabilities: list[str] | None = None,
+    ) -> str:
+        """Serialize an online status message (retained, heartbeat every 30s)."""
+        return self._status("online", version, capabilities)
+
+    def status_offline(self) -> str:
+        """Serialize an offline status message (timestamp=0 for LWT)."""
+        return json.dumps({
+            "device": self.device,
+            "msg_type": "status",
+            "status": "offline",
+            "timestamp": 0,
+        })
+
+    def discovery(self, elements: list[str]) -> str:
+        """Serialize a discovery message (retained)."""
+        return json.dumps({
+            "device": self.device,
+            "msg_type": "discovery",
+            "timestamp": int(time.time()),
+            "elements": elements,
+        })
+
+    def command(
+        self,
+        action: str,
+        value: str = "",
+        request_id: str | None = None,
+        **extra: Any,
+    ) -> str:
+        """Serialize a command/request message."""
+        msg: dict[str, Any] = {
+            "device": self.device,
+            "action": action,
+            "value": value,
+        }
+        if request_id:
+            msg["request_id"] = request_id
+        msg.update(extra)
+        return json.dumps(msg)
+
+    def response(
+        self,
+        action: str = "completed",
+        value: str = "",
+        request_id: str | None = None,
+        status: str = "success",
+        **extra: Any,
+    ) -> str:
+        """Serialize a command response message."""
+        msg: dict[str, Any] = {
+            "device": self.device,
+            "action": action,
+            "value": value,
+            "status": status,
+            "timestamp": int(time.time()),
+        }
+        if request_id:
+            msg["request_id"] = request_id
+        msg.update(extra)
+        return json.dumps(msg)
+
+    def _status(
+        self,
+        status: str,
+        version: str,
+        capabilities: list[str] | None,
+    ) -> str:
+        msg: dict[str, Any] = {
+            "device": self.device,
+            "msg_type": "status",
+            "status": status,
+            "timestamp": int(time.time()),
+            "version": version,
+        }
+        if capabilities:
+            msg["capabilities"] = capabilities
+        return json.dumps(msg)

--- a/simulation/layer1/ocp.py
+++ b/simulation/layer1/ocp.py
@@ -1,0 +1,239 @@
+"""
+OCP peer simulation — simulated peers that register, publish status, and
+maintain keepalive on the O.A.S.I.S. MQTT network.
+
+Two embodiment types are supported:
+
+* **E3** — physical hardware peer (real sensors, actuators).
+* **E4** — software-only peer (no physical body; used by simulation).
+
+Both follow the same MQTT lifecycle:
+
+1. Set Last Will and Testament (offline status, timestamp=0).
+2. Publish online status (retained).
+3. Publish discovery message (retained).
+4. Heartbeat every ``heartbeat_interval`` seconds (default 30).
+5. On shutdown, publish offline status and disconnect.
+
+Example::
+
+    import paho.mqtt.client as mqtt
+    from simulation.layer1.ocp import OCPPeer, Embodiment
+
+    client = mqtt.Client()
+    client.connect("localhost", 1883)
+    client.loop_start()
+
+    peer = OCPPeer(
+        client=client,
+        peer_id="echo-mirage-sim",
+        component="mirage",
+        embodiment=Embodiment.E4,
+        capabilities=["armor_display", "detect"],
+    )
+    peer.start()   # publishes online + discovery, starts heartbeat
+    # ... do work ...
+    peer.stop()    # publishes offline, stops heartbeat
+    client.loop_stop()
+"""
+
+from __future__ import annotations
+
+import enum
+import json
+import threading
+import time
+from typing import Any
+
+try:
+    import paho.mqtt.client as mqtt
+except ImportError as exc:
+    raise ImportError(
+        "Layer 1 requires paho-mqtt.  Install with:  "
+        'pip install "oasis-sim[layer1]"'
+    ) from exc
+
+from simulation.hal.network import OCPPeerInterface
+from simulation.layer1.mqtt import TopicBuilder, MessageSerializer
+
+
+class Embodiment(enum.Enum):
+    """OCP embodiment level.
+
+    E3 — physical hardware peer (sensors, actuators, real-world presence).
+    E4 — software-only peer (no physical body; simulation or pure-software agent).
+    """
+
+    E3 = "physical"
+    E4 = "software"
+
+
+class OCPPeer(OCPPeerInterface):
+    """A simulated OCP (OASIS Communications Protocol) peer that publishes status and keepalive over MQTT (Message Queuing Telemetry Transport).
+
+    Parameters
+    ----------
+    client : paho.mqtt.client.Client
+        A connected (and looping) MQTT client.
+    peer_id : str
+        Unique identifier for this peer (used in topic ``oasis/<peer_id>/status``).
+    component : str
+        O.A.S.I.S. component name (e.g., ``"mirage"``).
+    embodiment : Embodiment
+        E3 (physical) or E4 (software-only).
+    capabilities : list[str] | None
+        List of capabilities advertised in discovery messages.
+    version : str
+        Version string included in status messages.
+    heartbeat_interval : float
+        Seconds between heartbeat status publishes (default 30).
+    """
+
+    def __init__(
+        self,
+        client: mqtt.Client,
+        peer_id: str,
+        component: str,
+        embodiment: Embodiment = Embodiment.E4,
+        capabilities: list[str] | None = None,
+        version: str = "0.0.0-sim",
+        heartbeat_interval: float = 30.0,
+    ) -> None:
+        self.client = client
+        self.peer_id = peer_id
+        self.component = component
+        self.embodiment = embodiment
+        self.capabilities = capabilities or []
+        self.version = version
+        self.heartbeat_interval = heartbeat_interval
+
+        self._topics = TopicBuilder(component)
+        self._serializer = MessageSerializer(component)
+        self._heartbeat_timer: threading.Timer | None = None
+        self._running = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def set_lwt(self) -> None:
+        """Set the Last Will and Testament before connecting.
+
+        Call this *before* ``client.connect()`` if you want the broker to
+        publish an offline message on unexpected disconnect.  If the client
+        is already connected, this has no effect until the next reconnect.
+        """
+        self.client.will_set(
+            self._topics.status(),
+            payload=self._serializer.status_offline(),
+            qos=1,
+            retain=True,
+        )
+
+    def start(self) -> None:
+        """Publish online status and discovery, start heartbeat loop."""
+        self._running = True
+        self._publish_online()
+        self._publish_discovery()
+        self._publish_sim_discovery()
+        self._schedule_heartbeat()
+
+    def stop(self) -> None:
+        """Publish offline status and stop heartbeat."""
+        self._running = False
+        if self._heartbeat_timer is not None:
+            self._heartbeat_timer.cancel()
+            self._heartbeat_timer = None
+        self._publish_offline()
+
+    @property
+    def is_running(self) -> bool:
+        return self._running
+
+    # ------------------------------------------------------------------
+    # Internal publishing
+    # ------------------------------------------------------------------
+
+    def _publish_online(self) -> None:
+        self.client.publish(
+            self._topics.status(),
+            payload=self._serializer.status_online(
+                version=self.version,
+                capabilities=self.capabilities,
+            ),
+            qos=1,
+            retain=True,
+        )
+        # Also publish to per-peer topic for E3/E4 tracking
+        self.client.publish(
+            self._topics.peer_status(self.peer_id),
+            payload=json.dumps({
+                "peer_id": self.peer_id,
+                "component": self.component,
+                "embodiment": self.embodiment.value,
+                "status": "online",
+                "timestamp": int(time.time()),
+            }),
+            qos=1,
+            retain=True,
+        )
+
+    def _publish_offline(self) -> None:
+        self.client.publish(
+            self._topics.status(),
+            payload=self._serializer.status_offline(),
+            qos=1,
+            retain=True,
+        )
+        self.client.publish(
+            self._topics.peer_status(self.peer_id),
+            payload=json.dumps({
+                "peer_id": self.peer_id,
+                "component": self.component,
+                "embodiment": self.embodiment.value,
+                "status": "offline",
+                "timestamp": 0,
+            }),
+            qos=1,
+            retain=True,
+        )
+
+    def _publish_discovery(self) -> None:
+        if self.capabilities:
+            self.client.publish(
+                self._topics.discovery(None).replace("/#", ""),
+                payload=self._serializer.discovery(self.capabilities),
+                qos=1,
+                retain=True,
+            )
+
+    def _publish_sim_discovery(self) -> None:
+        """Publish to ``echo/discovery/simulates`` so other peers know this is simulated."""
+        self.client.publish(
+            self._topics.sim_discovery(),
+            payload=json.dumps({
+                "peer_id": self.peer_id,
+                "component": self.component,
+                "embodiment": self.embodiment.value,
+                "capabilities": self.capabilities,
+                "timestamp": int(time.time()),
+            }),
+            qos=1,
+            retain=True,
+        )
+
+    def _schedule_heartbeat(self) -> None:
+        if not self._running:
+            return
+        self._heartbeat_timer = threading.Timer(
+            self.heartbeat_interval,
+            self._heartbeat,
+        )
+        self._heartbeat_timer.daemon = True
+        self._heartbeat_timer.start()
+
+    def _heartbeat(self) -> None:
+        if not self._running:
+            return
+        self._publish_online()
+        self._schedule_heartbeat()

--- a/simulation/layer1/status_listeners.py
+++ b/simulation/layer1/status_listeners.py
@@ -1,0 +1,202 @@
+"""
+MQTT-based listeners for SimulationStatus events.
+
+These listeners bridge the SimulationStatus tracker (HAL layer) to the
+O.A.S.I.S. MQTT network, enabling all components to react to simulation
+status changes through their existing notification channels.
+
+Listeners:
+    MQTTBroadcastListener — publishes status events to ``echo/status`` (retained)
+    TTSNotificationListener — publishes human-readable announcements to the
+        ``dawn`` topic for D.A.W.N. TTS (text-to-speech) output
+    AudioAlertListener — publishes audio commands to the ``hud`` topic for
+        M.I.R.A.G.E. sound alerts on mode changes
+
+Example::
+
+    import paho.mqtt.client as mqtt
+    from simulation.hal.status import SimulationStatus
+    from simulation.layer1.status_listeners import (
+        MQTTBroadcastListener,
+        TTSNotificationListener,
+        AudioAlertListener,
+    )
+
+    client = mqtt.Client()
+    client.connect("localhost", 1883)
+    client.loop_start()
+
+    tracker = SimulationStatus("mirage")
+    tracker.add_listener(MQTTBroadcastListener(client))
+    tracker.add_listener(TTSNotificationListener(client))
+    tracker.add_listener(AudioAlertListener(client))
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+try:
+    import paho.mqtt.client as mqtt
+except ImportError as exc:
+    raise ImportError(
+        "Layer 1 requires paho-mqtt.  Install with:  "
+        'pip install "oasis-simulation[layer1]"'
+    ) from exc
+
+from simulation.hal.status import StatusChange, StatusEvent
+
+
+class MQTTBroadcastListener:
+    """Publishes all status events to ``echo/status`` as retained JSON messages.
+
+    Any component on the MQTT network can subscribe to ``echo/status`` to
+    track which interfaces across the ecosystem are simulated vs. real.
+
+    Parameters
+    ----------
+    client : paho.mqtt.client.Client
+        A connected MQTT client.
+    topic : str
+        Topic to publish to (default ``"echo/status"``).
+    qos : int
+        MQTT QoS level (default 1).
+    """
+
+    def __init__(
+        self,
+        client: mqtt.Client,
+        topic: str = "echo/status",
+        qos: int = 1,
+    ) -> None:
+        self.client = client
+        self.topic = topic
+        self.qos = qos
+
+    def __call__(self, event: StatusEvent) -> None:
+        payload = json.dumps(event.to_dict())
+        self.client.publish(self.topic, payload=payload, qos=self.qos, retain=True)
+
+
+class TTSNotificationListener:
+    """Publishes human-readable status announcements to D.A.W.N. for TTS output.
+
+    Only triggers on mode changes (simulated to live, or live to simulated) —
+    same-mode swaps and registrations are silent to avoid notification fatigue.
+
+    The message is published to the ``dawn`` topic in D.A.W.N.'s OCP command
+    format, requesting text-to-speech output.
+
+    Parameters
+    ----------
+    client : paho.mqtt.client.Client
+        A connected MQTT client.
+    topic : str
+        Topic for D.A.W.N. TTS commands (default ``"dawn"``).
+    """
+
+    def __init__(
+        self,
+        client: mqtt.Client,
+        topic: str = "dawn",
+    ) -> None:
+        self.client = client
+        self.topic = topic
+
+    def __call__(self, event: StatusEvent) -> None:
+        # Only announce mode changes (simulated ↔ live)
+        if event.change != StatusChange.SWAPPED:
+            return
+        if event.was_simulated == event.is_simulated:
+            return
+
+        self.client.publish(
+            self.topic,
+            payload=json.dumps({
+                "device": "simulation",
+                "action": "speak",
+                "value": event.message,
+                "timestamp": int(time.time()),
+            }),
+            qos=1,
+        )
+
+
+class AudioAlertListener:
+    """Publishes audio alert commands to M.I.R.A.G.E. on mode changes.
+
+    Triggers a notification sound on the HUD when an interface switches
+    between simulated and live mode.
+
+    Parameters
+    ----------
+    client : paho.mqtt.client.Client
+        A connected MQTT client.
+    topic : str
+        Topic for M.I.R.A.G.E. audio commands (default ``"hud"``).
+    alert_sound : str
+        Sound file name for the alert (default ``"sim_status_change"``).
+    """
+
+    def __init__(
+        self,
+        client: mqtt.Client,
+        topic: str = "hud",
+        alert_sound: str = "sim_status_change",
+    ) -> None:
+        self.client = client
+        self.topic = topic
+        self.alert_sound = alert_sound
+
+    def __call__(self, event: StatusEvent) -> None:
+        # Only alert on mode changes
+        if event.change != StatusChange.SWAPPED:
+            return
+        if event.was_simulated == event.is_simulated:
+            return
+
+        self.client.publish(
+            self.topic,
+            payload=json.dumps({
+                "device": "simulation",
+                "action": "audio",
+                "value": self.alert_sound,
+                "timestamp": int(time.time()),
+            }),
+            qos=1,
+        )
+
+
+class WebUIStatusListener:
+    """Publishes status events for D.A.W.N.'s WebUI to consume.
+
+    Publishes to a dedicated topic that the WebUI can subscribe to
+    for displaying simulation status in the interface.
+
+    Parameters
+    ----------
+    client : paho.mqtt.client.Client
+        A connected MQTT client.
+    topic : str
+        Topic for WebUI status updates (default ``"echo/status/webui"``).
+    """
+
+    def __init__(
+        self,
+        client: mqtt.Client,
+        topic: str = "echo/status/webui",
+    ) -> None:
+        self.client = client
+        self.topic = topic
+
+    def __call__(self, event: StatusEvent) -> None:
+        self.client.publish(
+            self.topic,
+            payload=json.dumps({
+                "type": "simulation_status",
+                "payload": event.to_dict(),
+            }),
+            qos=1,
+        )

--- a/tests/test_layer1.py
+++ b/tests/test_layer1.py
@@ -1,0 +1,585 @@
+"""Tests for Layer 1 — protocol simulation (MQTT helpers, OCP peers, DAP2 client)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# MQTT topic helpers
+# ---------------------------------------------------------------------------
+
+from simulation.layer1.mqtt import TopicBuilder, MessageSerializer
+
+
+class TestTopicBuilder:
+    """TopicBuilder constructs MQTT topic strings per OCP conventions."""
+
+    def test_status_topic_mirage(self):
+        tb = TopicBuilder("mirage")
+        assert tb.status() == "hud/status"
+
+    def test_status_topic_dawn(self):
+        tb = TopicBuilder("dawn")
+        assert tb.status() == "dawn/status"
+
+    def test_status_topic_unknown_component(self):
+        tb = TopicBuilder("custom")
+        assert tb.status() == "custom/status"
+
+    def test_discovery_with_capability(self):
+        tb = TopicBuilder("mirage")
+        assert tb.discovery("map") == "hud/discovery/map"
+
+    def test_discovery_wildcard(self):
+        tb = TopicBuilder("mirage")
+        assert tb.discovery() == "hud/discovery/#"
+
+    def test_command_topic(self):
+        tb = TopicBuilder("dawn")
+        assert tb.command() == "dawn"
+
+    def test_command_topic_mirage(self):
+        tb = TopicBuilder("mirage")
+        assert tb.command() == "hud"
+
+    def test_broadcast(self):
+        tb = TopicBuilder("mirage")
+        assert tb.broadcast() == "oasis/broadcast"
+
+    def test_peer_status(self):
+        tb = TopicBuilder("mirage")
+        assert tb.peer_status("echo-sim-1") == "oasis/echo-sim-1/status"
+
+    def test_sim_discovery(self):
+        tb = TopicBuilder("mirage")
+        assert tb.sim_discovery() == "echo/discovery/simulates"
+
+    def test_case_insensitive(self):
+        tb = TopicBuilder("MIRAGE")
+        assert tb.status() == "hud/status"
+
+    def test_all_known_components(self):
+        expected = {
+            "mirage": "hud",
+            "dawn": "dawn",
+            "aura": "aura",
+            "spark": "spark",
+            "stat": "stat",
+            "beacon": "beacon",
+            "genesis": "genesis",
+            "scope": "scope",
+        }
+        for comp, base in expected.items():
+            tb = TopicBuilder(comp)
+            assert tb.base == base, f"TopicBuilder({comp!r}).base != {base!r}"
+
+
+class TestMessageSerializer:
+    """MessageSerializer produces valid OCP JSON messages."""
+
+    def test_status_online(self):
+        ms = MessageSerializer("mirage")
+        raw = ms.status_online(version="2.1.0", capabilities=["detect"])
+        msg = json.loads(raw)
+        assert msg["device"] == "mirage"
+        assert msg["msg_type"] == "status"
+        assert msg["status"] == "online"
+        assert msg["version"] == "2.1.0"
+        assert msg["capabilities"] == ["detect"]
+        assert msg["timestamp"] > 0
+
+    def test_status_offline(self):
+        ms = MessageSerializer("dawn")
+        raw = ms.status_offline()
+        msg = json.loads(raw)
+        assert msg["device"] == "dawn"
+        assert msg["status"] == "offline"
+        assert msg["timestamp"] == 0
+
+    def test_discovery(self):
+        ms = MessageSerializer("mirage")
+        raw = ms.discovery(["armor_display", "detect", "map"])
+        msg = json.loads(raw)
+        assert msg["device"] == "mirage"
+        assert msg["msg_type"] == "discovery"
+        assert msg["elements"] == ["armor_display", "detect", "map"]
+        assert msg["timestamp"] > 0
+
+    def test_command(self):
+        ms = MessageSerializer("viewing")
+        raw = ms.command(action="look", value="describe what you see", request_id="dawn_42")
+        msg = json.loads(raw)
+        assert msg["device"] == "viewing"
+        assert msg["action"] == "look"
+        assert msg["value"] == "describe what you see"
+        assert msg["request_id"] == "dawn_42"
+
+    def test_command_no_request_id(self):
+        ms = MessageSerializer("dawn")
+        raw = ms.command(action="speak", value="hello")
+        msg = json.loads(raw)
+        assert "request_id" not in msg
+
+    def test_command_extra_fields(self):
+        ms = MessageSerializer("dawn")
+        raw = ms.command(action="speak", value="hello", priority="high")
+        msg = json.loads(raw)
+        assert msg["priority"] == "high"
+
+    def test_response(self):
+        ms = MessageSerializer("mirage")
+        raw = ms.response(
+            action="completed",
+            value="/tmp/screenshot.jpg",
+            request_id="dawn_42",
+            checksum="abc123",
+        )
+        msg = json.loads(raw)
+        assert msg["device"] == "mirage"
+        assert msg["action"] == "completed"
+        assert msg["status"] == "success"
+        assert msg["request_id"] == "dawn_42"
+        assert msg["checksum"] == "abc123"
+        assert msg["timestamp"] > 0
+
+    def test_response_no_request_id(self):
+        ms = MessageSerializer("dawn")
+        raw = ms.response(action="completed", value="done")
+        msg = json.loads(raw)
+        assert "request_id" not in msg
+
+    def test_status_online_no_capabilities(self):
+        ms = MessageSerializer("stat")
+        raw = ms.status_online(version="1.0")
+        msg = json.loads(raw)
+        assert "capabilities" not in msg
+
+    def test_case_insensitive_device(self):
+        ms = MessageSerializer("MIRAGE")
+        raw = ms.status_online()
+        msg = json.loads(raw)
+        assert msg["device"] == "mirage"
+
+
+# ---------------------------------------------------------------------------
+# OCP peer simulation
+# ---------------------------------------------------------------------------
+
+from simulation.layer1.ocp import OCPPeer, Embodiment
+
+
+class TestEmbodiment:
+    """Embodiment enum represents E3 (physical) and E4 (software)."""
+
+    def test_e3_value(self):
+        assert Embodiment.E3.value == "physical"
+
+    def test_e4_value(self):
+        assert Embodiment.E4.value == "software"
+
+
+class TestOCPPeer:
+    """OCPPeer publishes OCP status, discovery, and heartbeat over MQTT."""
+
+    def _make_mock_client(self) -> MagicMock:
+        client = MagicMock()
+        client.publish = MagicMock()
+        client.will_set = MagicMock()
+        return client
+
+    def test_set_lwt(self):
+        client = self._make_mock_client()
+        peer = OCPPeer(client=client, peer_id="sim-1", component="mirage")
+        peer.set_lwt()
+        client.will_set.assert_called_once()
+        args, kwargs = client.will_set.call_args
+        assert args[0] == "hud/status"
+        msg = json.loads(kwargs["payload"])
+        assert msg["status"] == "offline"
+        assert msg["timestamp"] == 0
+
+    def test_start_publishes_status_and_discovery(self):
+        client = self._make_mock_client()
+        peer = OCPPeer(
+            client=client,
+            peer_id="sim-1",
+            component="mirage",
+            capabilities=["detect", "map"],
+            version="1.0.0-sim",
+        )
+        peer.start()
+        try:
+            # Should have published: online status, peer status, discovery, sim discovery
+            topics = [call.args[0] for call in client.publish.call_args_list]
+            assert "hud/status" in topics
+            assert "oasis/sim-1/status" in topics
+            assert "hud/discovery" in topics
+            assert "echo/discovery/simulates" in topics
+
+            # Verify online status content
+            for call in client.publish.call_args_list:
+                if call.args[0] == "hud/status":
+                    msg = json.loads(call.kwargs["payload"])
+                    assert msg["status"] == "online"
+                    assert msg["version"] == "1.0.0-sim"
+                    assert msg["capabilities"] == ["detect", "map"]
+                    break
+        finally:
+            peer.stop()
+
+    def test_start_sets_running(self):
+        client = self._make_mock_client()
+        peer = OCPPeer(client=client, peer_id="sim-1", component="dawn")
+        assert not peer.is_running
+        peer.start()
+        assert peer.is_running
+        peer.stop()
+        assert not peer.is_running
+
+    def test_stop_publishes_offline(self):
+        client = self._make_mock_client()
+        peer = OCPPeer(client=client, peer_id="sim-1", component="dawn")
+        peer.start()
+        client.publish.reset_mock()
+        peer.stop()
+
+        # Offline status should be published
+        topics = [call.args[0] for call in client.publish.call_args_list]
+        assert "dawn/status" in topics
+        for call in client.publish.call_args_list:
+            if call.args[0] == "dawn/status":
+                msg = json.loads(call.kwargs["payload"])
+                assert msg["status"] == "offline"
+                assert msg["timestamp"] == 0
+                break
+
+    def test_e4_embodiment_in_peer_status(self):
+        client = self._make_mock_client()
+        peer = OCPPeer(
+            client=client,
+            peer_id="sim-1",
+            component="mirage",
+            embodiment=Embodiment.E4,
+        )
+        peer.start()
+        try:
+            for call in client.publish.call_args_list:
+                if call.args[0] == "oasis/sim-1/status":
+                    msg = json.loads(call.kwargs["payload"])
+                    assert msg["embodiment"] == "software"
+                    assert msg["peer_id"] == "sim-1"
+                    break
+            else:
+                pytest.fail("No peer status message published")
+        finally:
+            peer.stop()
+
+    def test_e3_embodiment(self):
+        client = self._make_mock_client()
+        peer = OCPPeer(
+            client=client,
+            peer_id="hw-1",
+            component="mirage",
+            embodiment=Embodiment.E3,
+        )
+        peer.start()
+        try:
+            for call in client.publish.call_args_list:
+                if call.args[0] == "oasis/hw-1/status":
+                    msg = json.loads(call.kwargs["payload"])
+                    assert msg["embodiment"] == "physical"
+                    break
+        finally:
+            peer.stop()
+
+    def test_no_discovery_without_capabilities(self):
+        client = self._make_mock_client()
+        peer = OCPPeer(
+            client=client,
+            peer_id="sim-1",
+            component="dawn",
+            capabilities=[],
+        )
+        peer.start()
+        try:
+            topics = [call.args[0] for call in client.publish.call_args_list]
+            assert "dawn/discovery" not in topics
+        finally:
+            peer.stop()
+
+    def test_sim_discovery_published(self):
+        client = self._make_mock_client()
+        peer = OCPPeer(
+            client=client,
+            peer_id="echo-sim",
+            component="mirage",
+            capabilities=["detect"],
+        )
+        peer.start()
+        try:
+            for call in client.publish.call_args_list:
+                if call.args[0] == "echo/discovery/simulates":
+                    msg = json.loads(call.kwargs["payload"])
+                    assert msg["peer_id"] == "echo-sim"
+                    assert msg["component"] == "mirage"
+                    assert msg["capabilities"] == ["detect"]
+                    break
+            else:
+                pytest.fail("No sim discovery message published")
+        finally:
+            peer.stop()
+
+    def test_heartbeat_interval_configurable(self):
+        client = self._make_mock_client()
+        peer = OCPPeer(
+            client=client,
+            peer_id="sim-1",
+            component="dawn",
+            heartbeat_interval=5.0,
+        )
+        assert peer.heartbeat_interval == 5.0
+
+    def test_default_version(self):
+        client = self._make_mock_client()
+        peer = OCPPeer(client=client, peer_id="sim-1", component="dawn")
+        assert peer.version == "0.0.0-sim"
+
+
+# ---------------------------------------------------------------------------
+# DAP2 satellite and mock daemon
+# ---------------------------------------------------------------------------
+
+from simulation.layer1.dap2_client import (
+    DAP2Satellite,
+    DAP2MockDaemon,
+    SatelliteInfo,
+    StreamResponse,
+)
+
+
+class TestSatelliteInfo:
+    """SatelliteInfo data class defaults."""
+
+    def test_defaults(self):
+        info = SatelliteInfo()
+        assert info.name == "Mock Satellite"
+        assert info.location == "simulation"
+        assert info.tier == 1
+        assert info.capabilities["local_asr"] is True
+        assert len(info.uuid) == 36  # UUID4 format
+
+    def test_custom_values(self):
+        info = SatelliteInfo(name="Kitchen", location="kitchen", tier=2)
+        assert info.name == "Kitchen"
+        assert info.location == "kitchen"
+        assert info.tier == 2
+
+
+class TestStreamResponse:
+    """StreamResponse data class."""
+
+    def test_fields(self):
+        sr = StreamResponse(stream_id=1, text="hello world", reason="complete")
+        assert sr.stream_id == 1
+        assert sr.text == "hello world"
+        assert sr.reason == "complete"
+        assert sr.states == []
+
+
+def _find_free_port() -> int:
+    """Find an available TCP port for testing."""
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+class TestDAP2Integration:
+    """Integration tests: DAP2MockDaemon + DAP2Satellite end-to-end."""
+
+    @pytest.fixture
+    def port(self):
+        return _find_free_port()
+
+    @pytest.mark.asyncio
+    async def test_register_and_query(self, port):
+        """Satellite registers with mock daemon and sends a query."""
+        daemon = DAP2MockDaemon(host="localhost", port=port)
+        await daemon.start()
+        try:
+            sat = DAP2Satellite(uri=f"ws://localhost:{port}", name="Test Sat", location="lab")
+            ack = await sat.connect()
+            assert ack["success"] is True
+            assert "session_id" in ack
+            assert sat.is_connected
+
+            response = await sat.query("turn on the lights")
+            assert isinstance(response, StreamResponse)
+            assert "turn on the lights" in response.text
+            assert response.reason == "complete"
+
+            await sat.disconnect()
+            assert not sat.is_connected
+        finally:
+            await daemon.stop()
+
+    @pytest.mark.asyncio
+    async def test_custom_query_handler(self, port):
+        """Mock daemon uses custom query handler for responses."""
+        def handler(text: str) -> str:
+            if "lights" in text:
+                return "I'll turn on the lights. They should be on now."
+            return "I don't understand."
+
+        daemon = DAP2MockDaemon(host="localhost", port=port, query_handler=handler)
+        await daemon.start()
+        try:
+            sat = DAP2Satellite(uri=f"ws://localhost:{port}")
+            await sat.connect()
+
+            r1 = await sat.query("turn on the lights")
+            assert "turn on the lights" in r1.text
+            assert "should be on now" in r1.text
+
+            r2 = await sat.query("do something random")
+            assert "I don't understand" in r2.text
+
+            await sat.disconnect()
+        finally:
+            await daemon.stop()
+
+    @pytest.mark.asyncio
+    async def test_async_query_handler(self, port):
+        """Mock daemon supports async query handlers."""
+        async def handler(text: str) -> str:
+            await asyncio.sleep(0.01)  # simulate processing
+            return f"Processed: {text}"
+
+        daemon = DAP2MockDaemon(host="localhost", port=port, query_handler=handler)
+        await daemon.start()
+        try:
+            sat = DAP2Satellite(uri=f"ws://localhost:{port}")
+            await sat.connect()
+
+            response = await sat.query("test async")
+            assert response.text == "Processed: test async "
+
+            await sat.disconnect()
+        finally:
+            await daemon.stop()
+
+    @pytest.mark.asyncio
+    async def test_state_messages_captured(self, port):
+        """Satellite captures state messages (thinking, etc.) during query."""
+        daemon = DAP2MockDaemon(host="localhost", port=port)
+        await daemon.start()
+        try:
+            sat = DAP2Satellite(uri=f"ws://localhost:{port}")
+            await sat.connect()
+
+            response = await sat.query("hello")
+            # Daemon sends a "thinking" state before the stream
+            assert len(response.states) >= 1
+            assert response.states[0]["state"] == "thinking"
+
+            await sat.disconnect()
+        finally:
+            await daemon.stop()
+
+    @pytest.mark.asyncio
+    async def test_multiple_queries(self, port):
+        """Satellite can send multiple queries on the same connection."""
+        daemon = DAP2MockDaemon(host="localhost", port=port)
+        await daemon.start()
+        try:
+            sat = DAP2Satellite(uri=f"ws://localhost:{port}")
+            await sat.connect()
+
+            r1 = await sat.query("first")
+            r2 = await sat.query("second")
+            assert "first" in r1.text
+            assert "second" in r2.text
+            # Stream IDs should increment
+            assert r2.stream_id > r1.stream_id
+
+            await sat.disconnect()
+        finally:
+            await daemon.stop()
+
+    @pytest.mark.asyncio
+    async def test_query_before_connect_raises(self):
+        """Querying without connecting raises RuntimeError."""
+        sat = DAP2Satellite(uri="ws://localhost:9999")
+        with pytest.raises(RuntimeError, match="Not connected"):
+            await sat.query("hello")
+
+    @pytest.mark.asyncio
+    async def test_satellite_info_used_in_registration(self, port):
+        """Custom SatelliteInfo is used in the registration payload."""
+        daemon = DAP2MockDaemon(host="localhost", port=port)
+        await daemon.start()
+        try:
+            info = SatelliteInfo(name="Custom Sat", location="garage", tier=1)
+            sat = DAP2Satellite(uri=f"ws://localhost:{port}", info=info)
+            ack = await sat.connect()
+            assert "Custom Sat" in ack["message"]
+
+            await sat.disconnect()
+        finally:
+            await daemon.stop()
+
+    @pytest.mark.asyncio
+    async def test_reconnect_secret_stored(self, port):
+        """Satellite stores the reconnect secret from registration ack."""
+        daemon = DAP2MockDaemon(host="localhost", port=port)
+        await daemon.start()
+        try:
+            sat = DAP2Satellite(uri=f"ws://localhost:{port}")
+            await sat.connect()
+            assert sat._reconnect_secret is not None
+            assert sat._session_id is not None
+
+            await sat.disconnect()
+        finally:
+            await daemon.stop()
+
+    @pytest.mark.asyncio
+    async def test_disconnect_idempotent(self, port):
+        """Calling disconnect multiple times does not raise."""
+        daemon = DAP2MockDaemon(host="localhost", port=port)
+        await daemon.start()
+        try:
+            sat = DAP2Satellite(uri=f"ws://localhost:{port}")
+            await sat.connect()
+            await sat.disconnect()
+            await sat.disconnect()  # should not raise
+        finally:
+            await daemon.stop()
+
+    @pytest.mark.asyncio
+    async def test_multiple_satellites(self, port):
+        """Multiple satellites can connect to the same daemon."""
+        daemon = DAP2MockDaemon(host="localhost", port=port)
+        await daemon.start()
+        try:
+            sat1 = DAP2Satellite(uri=f"ws://localhost:{port}", name="Sat 1")
+            sat2 = DAP2Satellite(uri=f"ws://localhost:{port}", name="Sat 2")
+            ack1 = await sat1.connect()
+            ack2 = await sat2.connect()
+            # Each gets a unique session ID
+            assert ack1["session_id"] != ack2["session_id"]
+
+            r1 = await sat1.query("from sat1")
+            r2 = await sat2.query("from sat2")
+            assert "sat1" in r1.text
+            assert "sat2" in r2.text
+
+            await sat1.disconnect()
+            await sat2.disconnect()
+        finally:
+            await daemon.stop()

--- a/tests/test_status_listeners.py
+++ b/tests/test_status_listeners.py
@@ -1,0 +1,268 @@
+"""Tests for MQTT-based SimulationStatus listeners."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from simulation.hal.status import SimulationStatus, StatusChange, StatusEvent
+from simulation.layer0.camera import MockCamera
+from simulation.layer0.sensor import MockSensor
+from simulation.hal.provider import Provider
+from simulation.layer1.status_listeners import (
+    MQTTBroadcastListener,
+    TTSNotificationListener,
+    AudioAlertListener,
+    WebUIStatusListener,
+)
+
+
+def _make_mock_client() -> MagicMock:
+    client = MagicMock()
+    client.publish = MagicMock()
+    return client
+
+
+def _make_swap_event(
+    was_simulated: bool = True,
+    is_simulated: bool = False,
+    interface: str = "camera",
+) -> StatusEvent:
+    return StatusEvent(
+        change=StatusChange.SWAPPED,
+        interface=interface,
+        implementation="RealCamera" if not is_simulated else "MockCamera",
+        previous_implementation="MockCamera" if was_simulated else "RealCamera",
+        is_simulated=is_simulated,
+        was_simulated=was_simulated,
+    )
+
+
+class TestMQTTBroadcastListener:
+    """MQTTBroadcastListener publishes all events to echo/status."""
+
+    def test_publishes_on_register(self):
+        client = _make_mock_client()
+        listener = MQTTBroadcastListener(client)
+        tracker = SimulationStatus("test")
+        tracker.add_listener(listener)
+        tracker.register("camera", MockCamera())
+
+        client.publish.assert_called()
+        call = client.publish.call_args
+        assert call.args[0] == "echo/status"
+        payload = json.loads(call.kwargs["payload"])
+        assert payload["change"] == "registered"
+        assert payload["interface"] == "camera"
+        assert payload["is_simulated"] is True
+
+    def test_publishes_on_swap(self):
+        client = _make_mock_client()
+        listener = MQTTBroadcastListener(client)
+        event = _make_swap_event()
+        listener(event)
+
+        client.publish.assert_called_once()
+        payload = json.loads(client.publish.call_args.kwargs["payload"])
+        assert payload["change"] == "swapped"
+        assert payload["is_simulated"] is False
+
+    def test_retained_message(self):
+        client = _make_mock_client()
+        listener = MQTTBroadcastListener(client)
+        listener(_make_swap_event())
+        assert client.publish.call_args.kwargs["retain"] is True
+
+    def test_custom_topic(self):
+        client = _make_mock_client()
+        listener = MQTTBroadcastListener(client, topic="custom/status")
+        listener(_make_swap_event())
+        assert client.publish.call_args.args[0] == "custom/status"
+
+
+class TestTTSNotificationListener:
+    """TTSNotificationListener announces mode changes via D.A.W.N. TTS."""
+
+    def test_announces_mode_change(self):
+        client = _make_mock_client()
+        listener = TTSNotificationListener(client)
+        event = _make_swap_event(was_simulated=True, is_simulated=False)
+        listener(event)
+
+        client.publish.assert_called_once()
+        call = client.publish.call_args
+        assert call.args[0] == "dawn"
+        payload = json.loads(call.kwargs["payload"])
+        assert payload["action"] == "speak"
+        assert "live" in payload["value"]
+        assert "camera" in payload["value"]
+
+    def test_silent_on_same_mode_swap(self):
+        client = _make_mock_client()
+        listener = TTSNotificationListener(client)
+        event = _make_swap_event(was_simulated=True, is_simulated=True)
+        listener(event)
+        client.publish.assert_not_called()
+
+    def test_silent_on_register(self):
+        client = _make_mock_client()
+        listener = TTSNotificationListener(client)
+        event = StatusEvent(
+            change=StatusChange.REGISTERED,
+            interface="camera",
+            implementation="MockCamera",
+            previous_implementation=None,
+            is_simulated=True,
+            was_simulated=None,
+        )
+        listener(event)
+        client.publish.assert_not_called()
+
+    def test_announces_degradation(self):
+        """Live → simulated (hardware disconnected) triggers TTS."""
+        client = _make_mock_client()
+        listener = TTSNotificationListener(client)
+        event = _make_swap_event(was_simulated=False, is_simulated=True)
+        listener(event)
+
+        payload = json.loads(client.publish.call_args.kwargs["payload"])
+        assert "simulated" in payload["value"]
+
+
+class TestAudioAlertListener:
+    """AudioAlertListener sends sound alerts to M.I.R.A.G.E. on mode changes."""
+
+    def test_alert_on_mode_change(self):
+        client = _make_mock_client()
+        listener = AudioAlertListener(client)
+        event = _make_swap_event(was_simulated=True, is_simulated=False)
+        listener(event)
+
+        client.publish.assert_called_once()
+        call = client.publish.call_args
+        assert call.args[0] == "hud"
+        payload = json.loads(call.kwargs["payload"])
+        assert payload["action"] == "audio"
+        assert payload["value"] == "sim_status_change"
+
+    def test_silent_on_same_mode(self):
+        client = _make_mock_client()
+        listener = AudioAlertListener(client)
+        event = _make_swap_event(was_simulated=True, is_simulated=True)
+        listener(event)
+        client.publish.assert_not_called()
+
+    def test_custom_sound(self):
+        client = _make_mock_client()
+        listener = AudioAlertListener(client, alert_sound="warning_beep")
+        listener(_make_swap_event())
+        payload = json.loads(client.publish.call_args.kwargs["payload"])
+        assert payload["value"] == "warning_beep"
+
+
+class TestWebUIStatusListener:
+    """WebUIStatusListener publishes events for D.A.W.N.'s WebUI."""
+
+    def test_publishes_all_events(self):
+        client = _make_mock_client()
+        listener = WebUIStatusListener(client)
+        event = _make_swap_event()
+        listener(event)
+
+        client.publish.assert_called_once()
+        payload = json.loads(client.publish.call_args.kwargs["payload"])
+        assert payload["type"] == "simulation_status"
+        assert payload["payload"]["interface"] == "camera"
+
+    def test_includes_registration_events(self):
+        client = _make_mock_client()
+        listener = WebUIStatusListener(client)
+        event = StatusEvent(
+            change=StatusChange.REGISTERED,
+            interface="sensor",
+            implementation="MockSensor",
+            previous_implementation=None,
+            is_simulated=True,
+            was_simulated=None,
+        )
+        listener(event)
+        client.publish.assert_called_once()
+
+
+class TestFullIntegration:
+    """End-to-end: Provider → SimulationStatus → MQTT listeners."""
+
+    def test_provider_swap_triggers_all_listeners(self):
+        client = _make_mock_client()
+        tracker = SimulationStatus("mirage")
+
+        broadcast = MQTTBroadcastListener(client)
+        tts = TTSNotificationListener(client)
+        audio = AudioAlertListener(client)
+        webui = WebUIStatusListener(client)
+
+        tracker.add_listener(broadcast)
+        tracker.add_listener(tts)
+        tracker.add_listener(audio)
+        tracker.add_listener(webui)
+
+        # Create provider with tracker integration
+        handler = tracker.create_swap_handler("camera")
+        mock_cam = MockCamera()
+        camera = Provider(mock_cam, on_swap=handler)
+        tracker.register("camera", mock_cam)
+
+        client.publish.reset_mock()
+
+        # Simulate real camera connected (mode change: simulated → live)
+        class RealCamera:
+            _is_simulated = False
+            def capture(self): return {}
+            def set_resolution(self, w, h): pass
+            def set_fps(self, f): pass
+            def get_properties(self): return {}
+            def release(self): pass
+
+        camera.swap(RealCamera())
+
+        # All 4 listeners should have published
+        # broadcast (echo/status) + tts (dawn) + audio (hud) + webui (echo/status/webui)
+        topics = [call.args[0] for call in client.publish.call_args_list]
+        assert "echo/status" in topics
+        assert "dawn" in topics
+        assert "hud" in topics
+        assert "echo/status/webui" in topics
+
+    def test_graceful_degradation_notifications(self):
+        """Camera disconnect → fall back to mock → all channels notified."""
+        client = _make_mock_client()
+        tracker = SimulationStatus("mirage")
+
+        tts = TTSNotificationListener(client)
+        tracker.add_listener(tts)
+
+        handler = tracker.create_swap_handler("camera")
+
+        class RealCamera:
+            _is_simulated = False
+            def capture(self): return {}
+            def set_resolution(self, w, h): pass
+            def set_fps(self, f): pass
+            def get_properties(self): return {}
+            def release(self): pass
+
+        camera = Provider(RealCamera(), on_swap=handler)
+        tracker.register("camera", RealCamera())
+
+        client.publish.reset_mock()
+
+        # Camera disconnected — fall back to mock
+        camera.swap(MockCamera())
+
+        # TTS should announce the degradation
+        client.publish.assert_called()
+        payload = json.loads(client.publish.call_args.kwargs["payload"])
+        assert "simulated" in payload["value"]
+        assert payload["action"] == "speak"


### PR DESCRIPTION
## Summary
Implement all Network layer HAL (Hardware Abstraction Layer) Abstract Base Classes:

- `TopicBuilder(TopicBuilderInterface)` — MQTT (Message Queuing Telemetry Transport) topic construction for all O.A.S.I.S. components
- `MessageSerializer(MessageSerializerInterface)` — OCP (OASIS Communications Protocol) message serialization (status, discovery, command, response)
- `OCPPeer(OCPPeerInterface)` — Simulated OCP peer with E3 (physical) / E4 (software) embodiment, status publishing, discovery, heartbeat, LWT (Last Will and Testament)
- `DAP2Satellite(DAP2SatelliteInterface)` — DAP2 (Dawn Audio Protocol 2.0) WebSocket client (register, query, streaming response collection)
- `DAP2MockDaemon(DAP2DaemonInterface)` — Standalone mock server for testing without a real D.A.W.N. instance

Also defines `simulation/hal/network.py` interface contracts.

## Type of Change
- [x] New feature
- [x] Documentation
- [ ] Bug fix
- [ ] Refactoring

## Testing
- [x] 47 Network layer tests — all passing (83 total with Device layer)
- [x] DAP2 integration tests: satellite ↔ mock daemon end-to-end
- [x] OCP peer tests: status, discovery, embodiment, heartbeat via mock MQTT client

## Checklist
- [x] Tests added (tests/test_layer1.py)
- [x] Documentation updated (layer1/__init__.py)
- [x] No breaking changes
- [x] HAL interfaces defined before implementations

**Stacked on**: PR #11 (Device layer)
Closes #9
Tracked by: malcolmhoward/the-oasis-project-meta-repo#38 (onboarding sequence)

---
🤖 Generated with [Claude Code](https://claude.ai/code)