### PR TITLE
Add Platform layer — Home Assistant, LLM, and Memory mocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**E.C.H.O.** (working name) is the O.A.S.I.S. simulation framework — drop-in replacements for the hardware, protocols, and services that O.A.S.I.S. components depend on at runtime. It enables development and testing on any 4 GB device with Python or Docker, without specialized hardware, GPUs, or external services.
+**E.C.H.O.** (working name) is the O.A.S.I.S. simulation framework — drop-in replacements for the hardware, protocols, and services that O.A.S.I.S. components depend on at runtime. It enables development and testing on any 2 GB device with Python or Docker, without specialized hardware, GPUs, or external services.
 
 The framework follows a language-independent HAL design, serving both Python components (D.A.W.N., S.C.O.P.E.) and C components (M.I.R.A.G.E., A.U.R.A., S.P.A.R.K.).
 
@@ -42,9 +42,22 @@ Layer stability is enforced structurally — a breaking change in the Platform l
 | `simulation/layer0/spi.py` | MockSPI (loopback; pluggable response handlers) |
 | `simulation/layer0/camera.py` | MockCamera (frame metadata dict; no pixel data) |
 | `simulation/layer0/audio.py` | MockMicrophone (synthetic PCM), MockSpeaker (null sink) |
-| `simulation/layer1/` | Network layer (in development) |
-| `simulation/layer2/` | Platform layer (in development) |
+| `simulation/layer1/mqtt.py` | MQTT topic publisher/subscriber helpers |
+| `simulation/layer1/ocp.py` | OCP peer registration with E1-E5 embodiment spectrum |
+| `simulation/layer1/dap2_client.py` | DAP2 satellite WebSocket client |
+| `simulation/layer1/status_listeners.py` | MQTT broadcast, TTS, audio alert, WebUI status listeners |
+| `simulation/layer2/ha_mock.py` | Home Assistant REST API mock (Flask) |
+| `simulation/layer2/llm_mock.py` | LLM response simulator (keyword-to-tool-call, streaming) |
+| `simulation/layer2/llm_http_server.py` | OpenAI-compatible `/v1/chat/completions` HTTP wrapper |
+| `simulation/layer2/memory_mock.py` | Memory/RAG stub (SQLite-backed, keyword retrieval) |
+| `simulation/hal/provider.py` | Runtime hot-swap Provider (thread-safe) |
+| `simulation/hal/status.py` | SimulationStatus tracker (per-interface registry, event listeners) |
 | `tests/test_layer0.py` | Device layer test suite |
+| `tests/test_layer1.py` | Network layer test suite |
+| `tests/test_layer2.py` | Platform layer test suite |
+| `tests/test_provider.py` | Provider hot-swap test suite |
+| `tests/test_status.py` | SimulationStatus test suite |
+| `tests/test_status_listeners.py` | Status listeners test suite |
 | `pyproject.toml` | Build config; optional dep groups per layer |
 
 ## Commands

--- a/README.md
+++ b/README.md
@@ -235,8 +235,6 @@ Enables testing of O.A.S.I.S. protocol interactions without live hardware:
 
 ### Platform Layer — Software Service Simulation
 
-> Platform layer is under active development. See `simulation/layer2/` for current status.
-
 In-process Flask servers and deterministic stubs for external services:
 
 - **`ha_mock.py`** — Home Assistant REST API mock (`/api/states`, `/api/services/...`)
@@ -272,7 +270,7 @@ cd simulation_framework && pip install -e .
 |-------|--------|
 | Device — Hardware primitives | **Available** |
 | Network — Protocol simulation | **Available** |
-| Platform — Service simulation | In development |
+| Platform — Service simulation | **Available** |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 Software simulators for O.A.S.I.S. hardware, protocols, and services — develop and test without physical hardware or live external service dependencies.
 
+## Why This Project?
+
+O.A.S.I.S. is a distributed system that spans NVIDIA Jetsons, Raspberry Pis, custom sensor arrays, and specialized software services. Without simulation, a contributor needs physical hardware or running infrastructure just to test their code. That is a steep barrier for an open-source project whose mission includes accessibility.
+
+The simulation framework removes that barrier. Every hardware interface and every external service dependency has a drop-in mock that runs on any 2 GB machine with Python or Docker. The goal is simple: **no contributor should be blocked by hardware they do not own**.
+
 ## Description
 
 The simulation framework provides drop-in replacements for the physical and software dependencies that O.A.S.I.S. components require at runtime:
@@ -58,8 +64,8 @@ There are two ways to use the simulation framework:
 
 | Access path | RAM | GPU | Host OS | Notes |
 |-------------|:---:|:---:|---------|-------|
-| Python simulation | 4 GB | Not required | Linux, macOS, Windows (WSL2), Chrome OS (Crostini) | Suitable for classroom use |
-| Docker image | 4 GB | Not required | **Linux, Windows, macOS** — any OS with Docker | Full simulation stack; no build required on recipient machine |
+| Python simulation | 2 GB | Not required | Linux, macOS, Windows (WSL2), Chrome OS (Crostini) | Suitable for classroom use |
+| Docker image | 2 GB | Not required | **Linux, Windows, macOS** — any OS with Docker | Full simulation stack; no build required on recipient machine |
 | Build locally | 8 GB | Not required | Linux (Debian/Ubuntu recommended) | Only needed for C/C++ source development |
 | Full target | 8 GB+ | Jetson GPU | Linux (JetPack) | Local LLM and real-time ASR viable |
 
@@ -230,8 +236,9 @@ speaker.stop()
 Enables testing of O.A.S.I.S. protocol interactions without live hardware:
 
 - **`mqtt.py`** — MQTT topic publisher/subscriber helpers with message serializers
-- **`ocp.py`** — OCP (O.A.S.I.S. Communications Protocol) request/response builder
+- **`ocp.py`** — OCP (O.A.S.I.S. Communications Protocol) peer registration with E1-E5 embodiment spectrum
 - **`dap2_client.py`** — DAP2 satellite WebSocket client (register, query, text-path command injection)
+- **`status_listeners.py`** — MQTT broadcast, TTS notification, audio alert, and WebUI status listeners
 
 ### Platform Layer — Software Service Simulation
 
@@ -239,7 +246,41 @@ In-process Flask servers and deterministic stubs for external services:
 
 - **`ha_mock.py`** — Home Assistant REST API mock (`/api/states`, `/api/services/...`)
 - **`llm_mock.py`** — LLM response simulator (keyword → tool call synthesis, streaming)
+- **`llm_http_server.py`** — OpenAI-compatible `/v1/chat/completions` HTTP wrapper around LLMMock
 - **`memory_mock.py`** — Memory/RAG stub (SQLite-backed fact store, keyword retrieval)
+
+### OCP Embodiment Spectrum
+
+OCP peers declare an embodiment type indicating their relationship to physical reality:
+
+| Type | Name | Description | Example |
+|------|------|-------------|---------|
+| E1 | Physical | Real hardware with sensors and actuators | Jetson, Raspberry Pi, Arduino |
+| E2 | Remote-Physical | Real hardware, remote operator | Robot driven wirelessly |
+| E3 | Digital/Virtual | Game engine avatar, simulation peer | Godot character, E.C.H.O. mock |
+| E4 | Software-Only | No body — pure service/infrastructure | LLM routing, session management |
+| E5 | Hybrid | Spans multiple types via Provider | Real camera + simulated sensors |
+
+All five types are implemented across O.A.S.I.S. ecosystem branches. The `Embodiment` enum in `simulation/layer1/ocp.py` currently defines E3 (physical) and E4 (software). The full E1-E5 taxonomy is specified in ADR-0003 Amendment 5 in S.C.O.P.E.
+
+### HAL Architecture
+
+All mock classes implement interface contracts defined as ABCs (Abstract Base Classes) in `simulation/hal/`. Two cross-cutting components support runtime flexibility:
+
+- **Provider** (`simulation/hal/provider.py`) — Thread-safe runtime hot-swap wrapper. Component code programs against the HAL interface; the Provider manages which implementation (mock or real) is active and handles transparent swapping. Supports swap callbacks for notification (SimulationStatus, MQTT broadcast, TTS) and graceful degradation when hardware disconnects.
+
+  ```python
+  from simulation.hal.provider import Provider
+  from simulation.layer0.camera import MockCamera
+
+  camera = Provider(MockCamera())
+  frame = camera.capture()       # MockCamera.capture()
+  camera.swap(RealCamera())      # hot-swap at runtime
+  frame = camera.capture()       # RealCamera.capture()
+  camera.swap(MockCamera())      # graceful fallback
+  ```
+
+- **SimulationStatus** (`simulation/hal/status.py`) — Per-interface registry tracking whether each dependency is simulated or live. Supports event listeners for mode-change notifications (MQTT broadcast, TTS alerts, WebUI status, structured logging).
 
 ### Running Tests
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -189,3 +189,72 @@ Standalone DAP2 mock server for testing without D.A.W.N.
 | `host` | string | `"localhost"` | Bind address |
 | `port` | integer | `3000` | Bind port |
 | `query_handler` | callable or None | echo handler | `(text: str) -> str` response generator |
+
+---
+
+## Platform Layer — `simulation.layer2`
+
+### `simulation.hal.platform` — Interface Contracts
+
+| Interface | Methods | Description |
+|-----------|---------|-------------|
+| `HomeAssistantInterface` | `start()`, `stop()`, `get_states()`, `get_state(entity_id)`, `call_service(domain, service, data)` | Home Assistant REST API |
+| `LLMInterface` | `complete(prompt)`, `stream(prompt)`, `tool_call(prompt)` | LLM (Large Language Model) inference |
+| `MemoryInterface` | `store(text, metadata)`, `retrieve(query, top_k)`, `delete(fact_id)`, `count()` | RAG (Retrieval-Augmented Generation) fact store |
+
+### `HomeAssistantMock(HomeAssistantInterface)`
+
+Flask REST API server simulating Home Assistant.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `host` | string | `"localhost"` | Bind address |
+| `port` | integer | `8123` | Bind port |
+| `token` | string | `"mock-ha-token"` | Expected bearer token |
+| `entities` | list of maps or None | kitchen lights, bedroom lights, thermostat | Initial entity states |
+
+Supports: `turn_on`, `turn_off`, `toggle`, `set_temperature`. Access via HAL methods (`get_states()`, `call_service()`) or HTTP (`/api/states`, `/api/services/<domain>/<service>`).
+
+### `LLMMock(LLMInterface)`
+
+Keyword-to-response and keyword-to-tool-call mapping. Works like voice assistant skills (Amazon Alexa, Google Assistant) — recognized commands map to specific actions without AI inference.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `default_response` | string | `"I'm not sure..."` | Response when no rule matches |
+
+| Method | Description |
+|--------|-------------|
+| `add_rule(keyword, response)` | Map keyword to text response |
+| `add_tool_rule(keyword, tool, args)` | Map keyword to tool call |
+| `complete(prompt)` | Return matching response string |
+| `stream(prompt)` | Return word-level delta iterator |
+| `tool_call(prompt)` | Return matching tool call map or None |
+
+### `LLMHTTPServer`
+
+OpenAI-compatible HTTP wrapper for `LLMMock`. D.A.W.N.'s local LLM provider auto-detects this as a "generic OpenAI-compatible" endpoint.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `llm` | `LLMMock` | (required) | Mock LLM instance |
+| `host` | string | `"0.0.0.0"` | Bind address |
+| `port` | integer | `8080` | Bind port |
+| `model_name` | string | `"echo-mock"` | Model name in API responses |
+
+Endpoints: `POST /v1/chat/completions` (streaming and non-streaming), `GET /v1/models`.
+
+### `MemoryMock(MemoryInterface)`
+
+SQLite-backed fact store with keyword overlap scoring.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `db_path` | string | `":memory:"` | SQLite path; `":memory:"` for in-memory |
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `store(text, metadata)` | string (UUID) | Store a fact |
+| `retrieve(query, top_k)` | list of maps with `text`, `score`, optional `metadata` | Keyword-match retrieval |
+| `delete(fact_id)` | boolean | Delete by ID |
+| `count()` | integer | Total stored facts |

--- a/docs/component-integration.md
+++ b/docs/component-integration.md
@@ -1,0 +1,215 @@
+# Component Integration Guide
+
+How each O.A.S.I.S. component imports and uses the E.C.H.O. simulation framework for development and testing.
+
+## Quick Reference
+
+| Component | Layers Used | Primary Mock Classes |
+|-----------|-------------|---------------------|
+| M.I.R.A.G.E. | Device | `MockSensor` (motion, GPS, environmental), `MockCamera` |
+| D.A.W.N. | Device, Network, Platform | `MockSensor`, `DAP2Satellite`, `OCPPeer`, `HomeAssistantMock`, `LLMMock`, `MemoryMock` |
+| A.U.R.A. | Device | `MockSensor` (environmental), `MockI2C` |
+| S.P.A.R.K. | Device | `MockGPIO`, `MockSPI` |
+| S.T.A.T. | Device | `MockSensor` (system metrics, battery) |
+| S.C.O.P.E. | Network | `OCPPeer`, `TopicBuilder`, `MessageSerializer` |
+
+---
+
+## M.I.R.A.G.E. — HUD Display
+
+M.I.R.A.G.E. subscribes to MQTT topics and renders sensor data on its HUD. The simulation framework provides the sensor data publishers.
+
+### Installation
+
+```bash
+# As a git submodule in the M.I.R.A.G.E. repo
+git submodule add https://github.com/malcolmhoward/the-oasis-project-simulation-repo simulation_framework
+pip install -e "./simulation_framework"
+```
+
+### Usage — Mock Sensor Publisher
+
+```python
+import json
+import time
+import paho.mqtt.client as mqtt
+from simulation.layer0.sensor import MockSensor
+
+client = mqtt.Client()
+client.connect("localhost", 1883)
+
+imu = MockSensor("imu", sensor_type="motion")
+gps = MockSensor("gps", sensor_type="gps")
+enviro = MockSensor("enviro", sensor_type="environmental")
+
+while True:
+    client.publish("aura", json.dumps(imu.read()))
+    client.publish("aura", json.dumps(gps.read()))
+    client.publish("aura", json.dumps(enviro.read()))
+    time.sleep(1.0)
+```
+
+M.I.R.A.G.E. receives these messages on the `aura` topic and displays heading, pitch, roll, GPS coordinates, and environmental data — all from simulated values.
+
+### With Provider (runtime hot-swap)
+
+```python
+from simulation.hal.provider import Provider
+from simulation.layer0.camera import MockCamera
+
+# Start with mock camera
+camera = Provider(MockCamera(device_id=0, width=1920, height=1080))
+frame = camera.capture()  # simulated metadata
+
+# USB camera plugged in — swap to real driver
+# camera.swap(RealCamera(device_id=0))
+
+# USB camera unplugged — fall back to mock
+# camera.swap(MockCamera(device_id=0))
+```
+
+### Demo
+
+See [`demos/hud-mock/`](https://github.com/malcolmhoward/mirage/tree/feat/mirage/5-simulation-demo/demos/hud-mock) for a Docker Compose demo with broker + mock publisher + M.I.R.A.G.E. HUD.
+
+---
+
+## D.A.W.N. — AI Voice Assistant
+
+D.A.W.N. uses all three layers. The simulation framework provides mock services that D.A.W.N. connects to via its standard configuration (no code changes needed).
+
+### Service-Level Integration
+
+D.A.W.N. is a C application — it doesn't import Python mocks directly. Instead, the mocks run as HTTP/WebSocket servers that D.A.W.N. connects to:
+
+| D.A.W.N. Config | Mock Service | Port |
+|-----------------|-------------|------|
+| `[homeassistant] url` | `HomeAssistantMock` (Flask) | 8123 |
+| `[llm.local] endpoint` | `LLMHTTPServer` (OpenAI-compatible) | 8080 |
+| `[mqtt] broker` | Eclipse Mosquitto | 1883 |
+
+### Configuration (`dawn-simulation.toml`)
+
+```toml
+[llm]
+type = "local"
+
+[llm.local]
+endpoint = "http://mock-llm:8080"
+provider = "generic"
+
+[mqtt]
+broker = "mqtt-broker"
+
+[homeassistant]
+url = "http://mock-ha:8123"
+enabled = true
+
+[audio]
+enabled = false
+```
+
+### Demo
+
+See [`demos/full-mock/`](https://github.com/malcolmhoward/dawn/tree/feat/dawn/9-simulation-demo/demos/full-mock) for a Docker Compose demo with D.A.W.N. + mock services.
+
+---
+
+## A.U.R.A. — Helmet Sensors
+
+A.U.R.A. reads environmental sensors via I2C and publishes to MQTT. The simulation framework replaces the real I2C bus and sensors.
+
+### Usage
+
+```python
+from simulation.layer0.i2c import MockI2C
+from simulation.layer0.sensor import MockSensor
+
+# Simulate I2C environmental sensor (e.g., BME680)
+bus = MockI2C(bus_number=1)
+bus.write_byte_data(0x76, 0xD0, 0x61)  # WHO_AM_I for BME680
+
+# Or use MockSensor for higher-level data
+enviro = MockSensor("enviro", sensor_type="environmental")
+reading = enviro.read()
+# {"device": "Enviro", "temp": 22.5, "humidity": 65.0, "co2_ppm": 415.0, ...}
+```
+
+---
+
+## S.P.A.R.K. — Armor Actuators
+
+S.P.A.R.K. controls actuators via GPIO and communicates with sensors via SPI.
+
+### Usage
+
+```python
+from simulation.layer0.gpio import MockGPIO
+from simulation.layer0.spi import MockSPI
+
+# Simulate GPIO pin control (e.g., LED indicator)
+MockGPIO.setmode(MockGPIO.BCM)
+MockGPIO.setup(18, MockGPIO.OUT)
+MockGPIO.output(18, MockGPIO.HIGH)
+
+# Simulate SPI sensor (e.g., accelerometer with custom response)
+def accel_response(data):
+    if data[0] == 0x0F:  # WHO_AM_I register
+        return [0x33] + [0x00] * (len(data) - 1)
+    return [0x00] * len(data)
+
+spi = MockSPI(bus=0, device=0, response_handler=accel_response)
+device_id = spi.transfer([0x0F, 0x00])  # returns [0x33, 0x00]
+```
+
+---
+
+## S.T.A.T. — System Monitor
+
+S.T.A.T. reads system metrics (CPU, memory, temperature, battery) and publishes to MQTT.
+
+### Usage
+
+```python
+from simulation.layer0.sensor import MockSensor
+
+# System metrics don't have a dedicated sensor type yet —
+# use calibrate() to set base values for generic sensors
+system = MockSensor("system", sensor_type="temperature")
+system.calibrate(temperature=52.3)  # simulated CPU temperature
+reading = system.read()
+```
+
+For the MQTT publishing pattern, see the ecosystem demo's [`entrypoint.py`](https://github.com/malcolmhoward/the-oasis-project-meta-repo/tree/feat/scope/40-ecosystem-demo/demos/ecosystem-mock/mock_ecosystem/entrypoint.py) which publishes `SystemMetrics` and `BatteryStatus` on the `stat` topic.
+
+---
+
+## S.C.O.P.E. — Coordination
+
+S.C.O.P.E. coordinates the ecosystem and monitors component health via OCP.
+
+### Usage
+
+```python
+import paho.mqtt.client as mqtt
+from simulation.layer1.ocp import OCPPeer, Embodiment
+from simulation.layer1.mqtt import TopicBuilder, MessageSerializer
+
+client = mqtt.Client()
+client.connect("localhost", 1883)
+client.loop_start()
+
+# Register as a coordination peer
+scope = OCPPeer(
+    client=client,
+    peer_id="scope-coordination",
+    component="scope",
+    embodiment=Embodiment.E4,
+    capabilities=["coordination", "monitoring"],
+)
+scope.start()  # publishes status + discovery, starts heartbeat
+
+# Build and publish OCP messages
+serializer = MessageSerializer("scope")
+client.publish("oasis/broadcast", serializer.command(action="health_check"))
+```

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -178,6 +178,88 @@ The DAP2 satellite mock supports:
 - Text-path command injection
 - Synthetic `state`, `stream_delta`, `stream_end` responses
 
+## Platform Layer — Service Simulation
+
+The Platform layer (Layer 2) simulates the external software services that
+D.A.W.N. depends on at runtime. No GPU, API keys, or running services required.
+
+### LLM Mock — Voice Command Skills
+
+If you have used a voice assistant like Amazon Alexa or Google Assistant, the
+LLM (Large Language Model) mock works on the same principle: you define
+"skills" — recognized input patterns that map to specific actions — and the
+mock matches user input against those skills deterministically, without any
+AI inference.
+
+| Voice Assistant Concept | E.C.H.O. Equivalent |
+|------------------------|---------------------|
+| Alexa Skill / Google Action | `llm.add_tool_rule(keyword, tool, args)` |
+| Response template | `llm.add_rule(keyword, response)` |
+| NLU intent matching | Keyword substring matching (simpler, deterministic) |
+| Skill invokes a smart home API | Tool call output feeds into `HomeAssistantMock` |
+| "I don't know that" | `default_response` (configurable) |
+
+```python
+from simulation.layer2.llm_mock import LLMMock
+
+llm = LLMMock()
+
+# Define skills — recognized commands that map to tool calls
+llm.add_tool_rule("turn on the lights", tool="homeassistant",
+    args={"action": "turn_on", "entity_id": "light.kitchen_lights"})
+llm.add_tool_rule("turn off the lights", tool="homeassistant",
+    args={"action": "turn_off", "entity_id": "light.kitchen_lights"})
+
+# Define conversational responses
+llm.add_rule("weather", "It's sunny and 72 degrees.")
+llm.add_rule("hello", "Hey there! How can I help?")
+
+# Use in D.A.W.N.'s pipeline: speech → text → LLM mock → action
+result = llm.tool_call("turn on the lights please")
+# {"tool": "homeassistant", "args": {"action": "turn_on", "entity_id": "light.kitchen_lights"}}
+
+response = llm.complete("what's the weather today?")
+# "It's sunny and 72 degrees."
+```
+
+### Home Assistant Mock — Smart Home Control
+
+```python
+from simulation.layer2.ha_mock import HomeAssistantMock
+
+ha = HomeAssistantMock()
+
+# Check current state
+state = ha.get_state("light.kitchen_lights")
+print(state["state"])  # "off"
+
+# Turn on the lights (same call D.A.W.N. makes via tool execution)
+ha.call_service("light", "turn_on", {"entity_id": "light.kitchen_lights"})
+print(ha.get_state("light.kitchen_lights")["state"])  # "on"
+
+# Also runs as an HTTP server for integration testing
+ha.start()   # Flask server on localhost:8123
+# ... D.A.W.N. can now call http://localhost:8123/api/states ...
+ha.stop()
+```
+
+### Memory Mock — Fact Retrieval
+
+```python
+from simulation.layer2.memory_mock import MemoryMock
+
+mem = MemoryMock()
+
+# Store facts that D.A.W.N. can retrieve during conversation
+mem.store("The kitchen lights are Philips Hue bulbs.", metadata={"room": "kitchen"})
+mem.store("The thermostat is set to 21 degrees.", metadata={"room": "living room"})
+
+# Retrieve by keyword similarity
+results = mem.retrieve("kitchen lights")
+print(results[0]["text"])   # "The kitchen lights are Philips Hue bulbs."
+print(results[0]["score"])  # 1.0 (both query words found)
+```
+
 ## Troubleshooting
 
 ### Import Errors

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-E.C.H.O. provides drop-in replacements for the hardware, protocols, and services that O.A.S.I.S. components depend on at runtime. It enables development and testing on any 4 GB device with Python or Docker — no Jetson, no GPU, and no external services required.
+E.C.H.O. provides drop-in replacements for the hardware, protocols, and services that O.A.S.I.S. components depend on at runtime. It enables development and testing on any 2 GB device with Python or Docker — no Jetson, no GPU, and no external services required.
 
 The framework is organized into three independent layers:
 

--- a/simulation/hal/platform.py
+++ b/simulation/hal/platform.py
@@ -1,0 +1,152 @@
+"""
+Platform layer interface contracts — external service abstractions.
+
+These ABCs (Abstract Base Classes) define the API that both Python mock
+implementations (Layer 2) and future service test harnesses must conform to.
+
+Docstrings use language-neutral descriptions so alternative implementations
+(e.g., C service stubs) can be derived from the same definitions.
+
+- HomeAssistantInterface: Home Assistant REST API for smart home control,
+  used by D.A.W.N.'s tool execution pipeline
+- LLMInterface: LLM (Large Language Model) inference for natural language
+  processing, used by D.A.W.N.'s intent pipeline
+- MemoryInterface: RAG (Retrieval-Augmented Generation) memory store for
+  fact storage and retrieval, used by D.A.W.N.'s context system
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, AsyncIterator, Dict, List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Home Assistant
+# ---------------------------------------------------------------------------
+
+
+class HomeAssistantInterface(ABC):
+    """Interface for a Home Assistant REST API server.
+
+    Implementations must support entity state queries and service calls
+    with bearer token authentication.
+    """
+
+    @abstractmethod
+    def start(self) -> None:
+        """Start the server."""
+        ...
+
+    @abstractmethod
+    def stop(self) -> None:
+        """Stop the server."""
+        ...
+
+    @abstractmethod
+    def get_states(self) -> List[Dict[str, Any]]:
+        """Return all entity states as an array of string-keyed maps.
+
+        Each map contains at minimum: ``entity_id`` (string), ``state`` (string),
+        ``attributes`` (string-keyed map), ``last_changed`` (string, ISO 8601).
+        """
+        ...
+
+    @abstractmethod
+    def get_state(self, entity_id: str) -> Optional[Dict[str, Any]]:
+        """Return a single entity state as a string-keyed map, or null/None if not found.
+
+        entity_id: string (e.g., "light.kitchen_lights").
+        """
+        ...
+
+    @abstractmethod
+    def call_service(self, domain: str, service: str,
+                     data: Dict[str, Any]) -> None:
+        """Call a service with the given data.
+
+        domain: string (e.g., "light"), service: string (e.g., "turn_on"),
+        data: string-keyed map of service parameters (e.g., {"entity_id": "light.kitchen_lights"}).
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# LLM (Large Language Model)
+# ---------------------------------------------------------------------------
+
+
+class LLMInterface(ABC):
+    """Interface for an LLM (Large Language Model) inference service.
+
+    Implementations must support both synchronous (full response) and
+    streaming (delta-by-delta) response modes.
+    """
+
+    @abstractmethod
+    def complete(self, prompt: str, **kwargs: Any) -> str:
+        """Return a complete response string for the given prompt string."""
+        ...
+
+    @abstractmethod
+    def stream(self, prompt: str, **kwargs: Any) -> Any:
+        """Return an iterable of response delta strings for the given prompt string.
+
+        Each delta is a string fragment; concatenating all deltas produces the
+        full response.
+        """
+        ...
+
+    @abstractmethod
+    def tool_call(self, prompt: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        """Return a tool call as a string-keyed map if the prompt triggers one, else null/None.
+
+        Tool call map format::
+
+            {
+                "tool": "<tool_name>",     (string)
+                "args": {"arg": "value"}   (string-keyed map)
+            }
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
+# Memory / RAG (Retrieval-Augmented Generation)
+# ---------------------------------------------------------------------------
+
+
+class MemoryInterface(ABC):
+    """Interface for a fact store with keyword-based retrieval.
+
+    Implementations must support storing facts with metadata and
+    retrieving them by keyword search or semantic similarity.
+    """
+
+    @abstractmethod
+    def store(self, text: str, metadata: Optional[Dict[str, Any]] = None) -> str:
+        """Store a fact string with optional string-keyed metadata map.
+
+        Returns a unique string identifier for the stored entry.
+        """
+        ...
+
+    @abstractmethod
+    def retrieve(self, query: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        """Retrieve the most relevant facts for a query string.
+
+        top_k: integer maximum number of results.  Returns an array of
+        string-keyed maps, each containing at minimum ``"text"`` (string)
+        and ``"score"`` (float, 0.0 to 1.0).
+        """
+        ...
+
+    @abstractmethod
+    def delete(self, fact_id: str) -> bool:
+        """Delete a fact by string identifier.  Returns boolean (true if found and deleted)."""
+        ...
+
+    @abstractmethod
+    def count(self) -> int:
+        """Return the total number of stored facts as an integer."""
+        ...

--- a/simulation/layer2/__init__.py
+++ b/simulation/layer2/__init__.py
@@ -5,4 +5,9 @@ Install extras:
     pip install "oasis-simulation[layer2]"
 or:
     pip install flask
+
+Modules:
+    ha_mock      — Home Assistant REST API mock (Flask server + direct API)
+    llm_mock     — LLM (Large Language Model) keyword-to-response mock
+    memory_mock  — RAG (Retrieval-Augmented Generation) SQLite-backed fact store
 """

--- a/simulation/layer2/ha_mock.py
+++ b/simulation/layer2/ha_mock.py
@@ -1,0 +1,250 @@
+"""
+Home Assistant REST API mock — a lightweight Flask app that simulates the HA
+API endpoints used by D.A.W.N.'s tool execution pipeline.
+
+Supports:
+  - ``GET  /api/states``                — list all entity states
+  - ``GET  /api/states/{entity_id}``    — get a single entity state
+  - ``POST /api/services/{domain}/{service}`` — call a service (toggle, turn_on, etc.)
+  - Bearer token authentication (configurable; default ``mock-ha-token``)
+
+Example::
+
+    from simulation.layer2.ha_mock import HomeAssistantMock
+
+    ha = HomeAssistantMock(port=8123)
+    ha.start()          # starts Flask in a background thread
+    # ... DAWN can now call http://localhost:8123/api/states ...
+    ha.stop()
+
+Or use as an async context manager::
+
+    async with HomeAssistantMock(port=8123) as ha:
+        # server running
+        pass
+"""
+
+from __future__ import annotations
+
+import copy
+import threading
+import time
+from typing import Any
+
+try:
+    from flask import Flask, jsonify, request
+except ImportError as exc:
+    raise ImportError(
+        "Layer 2 requires flask.  Install with:  "
+        'pip install "oasis-simulation[layer2]"'
+    ) from exc
+
+
+# Default entities matching the meta-issue #30 spec
+_DEFAULT_ENTITIES: list[dict[str, Any]] = [
+    {
+        "entity_id": "light.kitchen_lights",
+        "state": "off",
+        "attributes": {
+            "friendly_name": "Kitchen Lights",
+            "brightness": 0,
+            "color_mode": "brightness",
+            "supported_features": 1,
+        },
+        "last_changed": "",
+        "last_updated": "",
+    },
+    {
+        "entity_id": "light.bedroom_lights",
+        "state": "off",
+        "attributes": {
+            "friendly_name": "Bedroom Lights",
+            "brightness": 0,
+            "color_mode": "brightness",
+            "supported_features": 1,
+        },
+        "last_changed": "",
+        "last_updated": "",
+    },
+    {
+        "entity_id": "climate.living_room_thermostat",
+        "state": "heat",
+        "attributes": {
+            "friendly_name": "Living Room Thermostat",
+            "temperature": 21.0,
+            "current_temperature": 19.5,
+            "hvac_modes": ["off", "heat", "cool", "auto"],
+            "min_temp": 7,
+            "max_temp": 35,
+        },
+        "last_changed": "",
+        "last_updated": "",
+    },
+]
+
+
+from simulation.hal.platform import HomeAssistantInterface
+
+
+class HomeAssistantMock(HomeAssistantInterface):
+    """Simulated Home Assistant REST API server.
+
+    Implements :class:`~simulation.hal.platform.HomeAssistantInterface`.
+
+    Parameters
+    ----------
+    host : str
+        Bind address (default ``"localhost"``).
+    port : int
+        Bind port (default ``8123``).
+    token : str
+        Expected bearer token (default ``"mock-ha-token"``).
+    entities : list[dict] | None
+        Initial entity states.  If ``None``, uses the default set
+        (kitchen lights, bedroom lights, living room thermostat).
+    """
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 8123,
+        token: str = "mock-ha-token",
+        entities: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.token = token
+        self.entities: dict[str, dict[str, Any]] = {}
+        self._service_log: list[dict[str, Any]] = []
+
+        for entity in (entities or copy.deepcopy(_DEFAULT_ENTITIES)):
+            eid = entity["entity_id"]
+            entity.setdefault("last_changed", self._now())
+            entity.setdefault("last_updated", self._now())
+            self.entities[eid] = entity
+
+        self._app = self._create_app()
+        self._thread: threading.Thread | None = None
+        self._server: Any = None
+
+    @property
+    def service_log(self) -> list[dict[str, Any]]:
+        """List of service calls received (for test assertions)."""
+        return list(self._service_log)
+
+    # ------------------------------------------------------------------
+    # HAL interface methods (direct access, no HTTP)
+    # ------------------------------------------------------------------
+
+    def get_states(self) -> list[dict[str, Any]]:
+        """Return all entity states as a list of string-keyed maps."""
+        return list(self.entities.values())
+
+    def get_state(self, entity_id: str) -> dict[str, Any] | None:
+        """Return a single entity state, or None if not found."""
+        return self.entities.get(entity_id)
+
+    def call_service(self, domain: str, service: str,
+                     data: dict[str, Any]) -> None:
+        """Call a service (e.g., light/turn_on) and update entity state."""
+        entity_id = data.get("entity_id")
+        self._service_log.append({
+            "domain": domain,
+            "service": service,
+            "data": data,
+            "timestamp": self._now(),
+        })
+        if entity_id and entity_id in self.entities:
+            entity = self.entities[entity_id]
+            now = self._now()
+            if service == "turn_on":
+                entity["state"] = "on"
+                if "brightness" in data:
+                    entity["attributes"]["brightness"] = data["brightness"]
+                elif entity["attributes"].get("brightness") == 0:
+                    entity["attributes"]["brightness"] = 255
+                entity["last_changed"] = now
+                entity["last_updated"] = now
+            elif service == "turn_off":
+                entity["state"] = "off"
+                entity["attributes"]["brightness"] = 0
+                entity["last_changed"] = now
+                entity["last_updated"] = now
+            elif service == "toggle":
+                new_state = "off" if entity["state"] == "on" else "on"
+                entity["state"] = new_state
+                if new_state == "on" and entity["attributes"].get("brightness") == 0:
+                    entity["attributes"]["brightness"] = 255
+                elif new_state == "off":
+                    entity["attributes"]["brightness"] = 0
+                entity["last_changed"] = now
+                entity["last_updated"] = now
+            elif service == "set_temperature":
+                if "temperature" in data:
+                    entity["attributes"]["temperature"] = data["temperature"]
+                entity["last_updated"] = now
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the mock HA server in a background thread."""
+        from werkzeug.serving import make_server
+
+        self._server = make_server(self.host, self.port, self._app)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the mock HA server."""
+        if self._server is not None:
+            self._server.shutdown()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    async def __aenter__(self) -> HomeAssistantMock:
+        self.start()
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        self.stop()
+
+    # ------------------------------------------------------------------
+    # Flask app
+    # ------------------------------------------------------------------
+
+    def _create_app(self) -> Flask:
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+
+        @app.before_request
+        def _check_auth() -> Any:
+            auth = request.headers.get("Authorization", "")
+            if auth != f"Bearer {self.token}":
+                return jsonify({"message": "Unauthorized"}), 401
+
+        @app.route("/api/states", methods=["GET"])
+        def _route_get_states() -> Any:
+            return jsonify(self.get_states())
+
+        @app.route("/api/states/<entity_id>", methods=["GET"])
+        def _route_get_state(entity_id: str) -> Any:
+            entity = self.get_state(entity_id)
+            if entity is None:
+                return jsonify({"message": f"Entity not found: {entity_id}"}), 404
+            return jsonify(entity)
+
+        @app.route("/api/services/<domain>/<service>", methods=["POST"])
+        def _route_call_service(domain: str, service: str) -> Any:
+            data = request.get_json(silent=True) or {}
+            self.call_service(domain, service, data)
+            return jsonify([{"entity_id": data.get("entity_id", "unknown")}])
+
+        return app
+
+    @staticmethod
+    def _now() -> str:
+        return time.strftime("%Y-%m-%dT%H:%M:%S+00:00", time.gmtime())

--- a/simulation/layer2/llm_http_server.py
+++ b/simulation/layer2/llm_http_server.py
@@ -1,0 +1,238 @@
+"""
+OpenAI-compatible HTTP server wrapper for LLMMock.
+
+Exposes the LLMMock as an HTTP endpoint that speaks the OpenAI
+``/v1/chat/completions`` API format.  D.A.W.N.'s local LLM provider
+auto-detects this as a "generic OpenAI-compatible" endpoint, so no
+D.A.W.N. code changes are needed — just point ``[llm.local] endpoint``
+at the mock server's URL.
+
+Also supports ``/v1/models`` for model listing and tool calling
+(function calling) responses.
+
+Example::
+
+    from simulation.layer2.llm_mock import LLMMock
+    from simulation.layer2.llm_http_server import LLMHTTPServer
+
+    llm = LLMMock()
+    llm.add_rule("weather", "It's sunny and 72 degrees.")
+    llm.add_tool_rule("turn on", tool="homeassistant",
+        args={"action": "turn_on", "entity_id": "light.kitchen_lights"})
+
+    server = LLMHTTPServer(llm, port=8080)
+    server.start()
+    # D.A.W.N. connects to http://localhost:8080/v1/chat/completions
+    server.stop()
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+import uuid
+from typing import Any
+
+try:
+    from flask import Flask, jsonify, request, Response
+except ImportError as exc:
+    raise ImportError(
+        "Layer 2 requires flask.  Install with:  "
+        'pip install "oasis-simulation[layer2]"'
+    ) from exc
+
+from simulation.layer2.llm_mock import LLMMock
+
+
+class LLMHTTPServer:
+    """OpenAI-compatible HTTP server backed by an LLMMock instance.
+
+    Parameters
+    ----------
+    llm : LLMMock
+        The mock LLM instance that handles prompt → response mapping.
+    host : str
+        Bind address (default ``"0.0.0.0"``).
+    port : int
+        Bind port (default ``8080``).
+    model_name : str
+        Model name returned in API responses (default ``"echo-mock"``).
+    """
+
+    def __init__(
+        self,
+        llm: LLMMock,
+        host: str = "0.0.0.0",
+        port: int = 8080,
+        model_name: str = "echo-mock",
+    ) -> None:
+        self.llm = llm
+        self.host = host
+        self.port = port
+        self.model_name = model_name
+        self._app = self._create_app()
+        self._thread: threading.Thread | None = None
+        self._server: Any = None
+
+    def start(self) -> None:
+        """Start the mock LLM server in a background thread."""
+        from werkzeug.serving import make_server
+
+        self._server = make_server(self.host, self.port, self._app)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the mock LLM server."""
+        if self._server is not None:
+            self._server.shutdown()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    def _create_app(self) -> Flask:
+        app = Flask(__name__)
+        app.config["TESTING"] = True
+
+        @app.route("/v1/chat/completions", methods=["POST"])
+        def chat_completions() -> Any:
+            data = request.get_json(silent=True) or {}
+            messages = data.get("messages", [])
+            stream = data.get("stream", False)
+
+            # Extract the last user message as the prompt
+            prompt = ""
+            for msg in reversed(messages):
+                if msg.get("role") == "user":
+                    content = msg.get("content", "")
+                    if isinstance(content, list):
+                        # Multi-modal: extract text parts
+                        prompt = " ".join(
+                            p.get("text", "") for p in content
+                            if isinstance(p, dict) and p.get("type") == "text"
+                        )
+                    else:
+                        prompt = content
+                    break
+
+            # Check for tool call first
+            tool_result = self.llm.tool_call(prompt)
+            if tool_result is not None:
+                return self._tool_call_response(tool_result, data)
+
+            # Regular text response
+            response_text = self.llm.complete(prompt)
+
+            if stream:
+                return self._streaming_response(response_text, data)
+            else:
+                return self._complete_response(response_text, data)
+
+        @app.route("/v1/models", methods=["GET"])
+        def list_models() -> Any:
+            return jsonify({
+                "object": "list",
+                "data": [{
+                    "id": self.model_name,
+                    "object": "model",
+                    "created": int(time.time()),
+                    "owned_by": "echo-simulation",
+                }],
+            })
+
+        return app
+
+    def _complete_response(self, text: str, req_data: dict) -> Any:
+        return jsonify({
+            "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": req_data.get("model", self.model_name),
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": text,
+                },
+                "finish_reason": "stop",
+            }],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": len(text.split()),
+                "total_tokens": 10 + len(text.split()),
+            },
+        })
+
+    def _tool_call_response(self, tool_result: dict, req_data: dict) -> Any:
+        return jsonify({
+            "id": f"chatcmpl-{uuid.uuid4().hex[:12]}",
+            "object": "chat.completion",
+            "created": int(time.time()),
+            "model": req_data.get("model", self.model_name),
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [{
+                        "id": f"call_{uuid.uuid4().hex[:8]}",
+                        "type": "function",
+                        "function": {
+                            "name": tool_result["tool"],
+                            "arguments": json.dumps(tool_result.get("args", {})),
+                        },
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        })
+
+    def _streaming_response(self, text: str, req_data: dict) -> Response:
+        model = req_data.get("model", self.model_name)
+        chat_id = f"chatcmpl-{uuid.uuid4().hex[:12]}"
+
+        def generate():
+            # Send chunks word by word
+            words = text.split(" ")
+            for i, word in enumerate(words):
+                delta = word + (" " if i < len(words) - 1 else "")
+                chunk = {
+                    "id": chat_id,
+                    "object": "chat.completion.chunk",
+                    "created": int(time.time()),
+                    "model": model,
+                    "choices": [{
+                        "index": 0,
+                        "delta": {"content": delta},
+                        "finish_reason": None,
+                    }],
+                }
+                yield f"data: {json.dumps(chunk)}\n\n"
+
+            # Send final chunk
+            final = {
+                "id": chat_id,
+                "object": "chat.completion.chunk",
+                "created": int(time.time()),
+                "model": model,
+                "choices": [{
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "stop",
+                }],
+            }
+            yield f"data: {json.dumps(final)}\n\n"
+            yield "data: [DONE]\n\n"
+
+        return Response(
+            generate(),
+            mimetype="text/event-stream",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )

--- a/simulation/layer2/llm_mock.py
+++ b/simulation/layer2/llm_mock.py
@@ -1,0 +1,112 @@
+"""
+LLM (Large Language Model) response mock — keyword-to-tool-call mapping with
+streaming delta support.
+
+No actual model weights are loaded.  Responses are determined by a configurable
+keyword map: if the prompt contains a keyword, the corresponding response or
+tool call is returned.  This enables deterministic testing of D.A.W.N.'s
+intent-processing pipeline without GPU, API keys, or network access.
+
+This works on the same principle as voice assistant "skills" (e.g., Amazon
+Alexa Skills or Google Actions): you define recognized input patterns that
+map to specific actions, and the mock matches user input against those
+patterns deterministically.  See ``docs/guide.md`` for a detailed comparison.
+
+Example::
+
+    from simulation.layer2.llm_mock import LLMMock
+
+    llm = LLMMock()
+    llm.add_rule("lights", response="I'll turn on the lights for you.")
+    llm.add_tool_rule("lights on", tool="homeassistant", args={"action": "turn_on", "entity_id": "light.kitchen_lights"})
+
+    print(llm.complete("turn on the lights"))
+    # "I'll turn on the lights for you."
+
+    print(llm.tool_call("lights on please"))
+    # {"tool": "homeassistant", "args": {"action": "turn_on", "entity_id": "light.kitchen_lights"}}
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterator, List, Optional
+
+from simulation.hal.platform import LLMInterface
+
+
+class LLMMock(LLMInterface):
+    """Keyword-driven LLM (Large Language Model) mock.
+
+    Implements :class:`~simulation.hal.platform.LLMInterface`.
+
+    Responses are matched by scanning the prompt for keywords.  Rules are
+    evaluated in insertion order; the first match wins.  If no rule matches,
+    the default response is returned.
+
+    Parameters
+    ----------
+    default_response : str
+        Response returned when no keyword rule matches.
+    """
+
+    def __init__(self, default_response: str = "I'm not sure how to help with that.") -> None:
+        self.default_response = default_response
+        self._response_rules: list[tuple[str, str]] = []
+        self._tool_rules: list[tuple[str, dict[str, Any]]] = []
+
+    def add_rule(self, keyword: str, response: str) -> None:
+        """Add a keyword-to-response rule.
+
+        keyword: string to search for in the prompt (case-insensitive).
+        response: string to return when the keyword is found.
+        """
+        self._response_rules.append((keyword.lower(), response))
+
+    def add_tool_rule(self, keyword: str, tool: str, args: Dict[str, Any] | None = None) -> None:
+        """Add a keyword-to-tool-call rule.
+
+        keyword: string to search for in the prompt (case-insensitive).
+        tool: string tool name.
+        args: string-keyed map of tool arguments.
+        """
+        self._tool_rules.append((keyword.lower(), {"tool": tool, "args": args or {}}))
+
+    # ------------------------------------------------------------------
+    # LLMInterface implementation
+    # ------------------------------------------------------------------
+
+    def complete(self, prompt: str, **kwargs: Any) -> str:
+        """Return a complete response string for the given prompt string.
+
+        Scans response rules in order; returns the first matching response,
+        or the default response if no rule matches.
+        """
+        prompt_lower = prompt.lower()
+        for keyword, response in self._response_rules:
+            if keyword in prompt_lower:
+                return response
+        return self.default_response
+
+    def stream(self, prompt: str, **kwargs: Any) -> Iterator[str]:
+        """Return an iterator of response delta strings.
+
+        Splits the complete response into word-level deltas to simulate
+        token-by-token streaming.
+        """
+        full_response = self.complete(prompt, **kwargs)
+        words = full_response.split(" ")
+        for i, word in enumerate(words):
+            yield word + (" " if i < len(words) - 1 else "")
+
+    def tool_call(self, prompt: str, **kwargs: Any) -> Optional[Dict[str, Any]]:
+        """Return a tool call map if the prompt triggers one, else None.
+
+        Scans tool rules in order; returns the first match.  Tool rules are
+        checked before response rules — if both match, the tool call takes
+        precedence.
+        """
+        prompt_lower = prompt.lower()
+        for keyword, call in self._tool_rules:
+            if keyword in prompt_lower:
+                return dict(call)
+        return None

--- a/simulation/layer2/memory_mock.py
+++ b/simulation/layer2/memory_mock.py
@@ -1,0 +1,119 @@
+"""
+Memory / RAG (Retrieval-Augmented Generation) stub — SQLite-backed fact store
+with keyword-match retrieval.
+
+No embedding model is loaded.  Retrieval uses simple keyword overlap scoring
+rather than vector similarity, enabling deterministic testing of D.A.W.N.'s
+context system without a running embedding service.
+
+Example::
+
+    from simulation.layer2.memory_mock import MemoryMock
+
+    mem = MemoryMock()
+    fact_id = mem.store("The kitchen lights are Philips Hue bulbs.", metadata={"room": "kitchen"})
+    results = mem.retrieve("kitchen lights")
+    print(results[0]["text"], results[0]["score"])
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from typing import Any, Dict, List, Optional
+
+from simulation.hal.platform import MemoryInterface
+
+
+class MemoryMock(MemoryInterface):
+    """Keyword-match fact store backed by SQLite.
+
+    Implements :class:`~simulation.hal.platform.MemoryInterface`.
+
+    Uses an in-memory SQLite database by default.  A file path can be
+    provided for persistence across sessions.
+
+    Parameters
+    ----------
+    db_path : str
+        SQLite database path.  Use ``":memory:"`` (default) for an
+        in-memory database that is discarded when the instance is
+        garbage-collected.
+    """
+
+    def __init__(self, db_path: str = ":memory:") -> None:
+        self._conn = sqlite3.connect(db_path, check_same_thread=False)
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS facts ("
+            "  id TEXT PRIMARY KEY,"
+            "  text TEXT NOT NULL,"
+            "  metadata TEXT"
+            ")"
+        )
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # MemoryInterface implementation
+    # ------------------------------------------------------------------
+
+    def store(self, text: str, metadata: Optional[Dict[str, Any]] = None) -> str:
+        """Store a fact string.  Returns a unique string identifier."""
+        import json
+        fact_id = str(uuid.uuid4())
+        self._conn.execute(
+            "INSERT INTO facts (id, text, metadata) VALUES (?, ?, ?)",
+            (fact_id, text, json.dumps(metadata) if metadata else None),
+        )
+        self._conn.commit()
+        return fact_id
+
+    def retrieve(self, query: str, top_k: int = 5) -> List[Dict[str, Any]]:
+        """Retrieve facts by keyword overlap scoring.
+
+        Splits the query into lowercase words and scores each fact by the
+        fraction of query words found in the fact text.  Returns up to
+        top_k results sorted by descending score.
+        """
+        import json
+        import re
+        _strip = re.compile(r"[^\w]")
+        query_words = {_strip.sub("", w) for w in query.lower().split()} - {""}
+        if not query_words:
+            return []
+
+        cursor = self._conn.execute("SELECT id, text, metadata FROM facts")
+        scored: list[tuple[float, dict[str, Any]]] = []
+
+        for row in cursor:
+            fact_id, text, meta_json = row
+            fact_words = {_strip.sub("", w) for w in text.lower().split()} - {""}
+            overlap = len(query_words & fact_words)
+            if overlap == 0:
+                continue
+            score = overlap / len(query_words)
+            result: dict[str, Any] = {
+                "id": fact_id,
+                "text": text,
+                "score": round(score, 4),
+            }
+            if meta_json:
+                result["metadata"] = json.loads(meta_json)
+            scored.append((score, result))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        return [item for _, item in scored[:top_k]]
+
+    def delete(self, fact_id: str) -> bool:
+        """Delete a fact by string identifier.  Returns true if found and deleted."""
+        cursor = self._conn.execute("DELETE FROM facts WHERE id = ?", (fact_id,))
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def count(self) -> int:
+        """Return the total number of stored facts as an integer."""
+        cursor = self._conn.execute("SELECT COUNT(*) FROM facts")
+        return cursor.fetchone()[0]
+
+    def close(self) -> None:
+        """Close the SQLite connection."""
+        self._conn.close()

--- a/tests/test_layer2.py
+++ b/tests/test_layer2.py
@@ -1,0 +1,317 @@
+"""Tests for Layer 2 — platform simulation (Home Assistant, LLM, Memory/RAG)."""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Home Assistant mock
+# ---------------------------------------------------------------------------
+
+from simulation.layer2.ha_mock import HomeAssistantMock
+
+
+def _find_free_port() -> int:
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("", 0))
+        return s.getsockname()[1]
+
+
+class TestHomeAssistantDirect:
+    """Test HomeAssistantMock via direct HAL interface (no HTTP)."""
+
+    def test_default_entities(self):
+        ha = HomeAssistantMock()
+        states = ha.get_states()
+        assert len(states) == 3
+        ids = {s["entity_id"] for s in states}
+        assert "light.kitchen_lights" in ids
+        assert "light.bedroom_lights" in ids
+        assert "climate.living_room_thermostat" in ids
+
+    def test_get_state_found(self):
+        ha = HomeAssistantMock()
+        state = ha.get_state("light.kitchen_lights")
+        assert state is not None
+        assert state["state"] == "off"
+        assert state["attributes"]["friendly_name"] == "Kitchen Lights"
+
+    def test_get_state_not_found(self):
+        ha = HomeAssistantMock()
+        assert ha.get_state("light.nonexistent") is None
+
+    def test_turn_on(self):
+        ha = HomeAssistantMock()
+        ha.call_service("light", "turn_on", {"entity_id": "light.kitchen_lights"})
+        state = ha.get_state("light.kitchen_lights")
+        assert state["state"] == "on"
+        assert state["attributes"]["brightness"] == 255
+
+    def test_turn_on_with_brightness(self):
+        ha = HomeAssistantMock()
+        ha.call_service("light", "turn_on", {"entity_id": "light.kitchen_lights", "brightness": 128})
+        state = ha.get_state("light.kitchen_lights")
+        assert state["state"] == "on"
+        assert state["attributes"]["brightness"] == 128
+
+    def test_turn_off(self):
+        ha = HomeAssistantMock()
+        ha.call_service("light", "turn_on", {"entity_id": "light.kitchen_lights"})
+        ha.call_service("light", "turn_off", {"entity_id": "light.kitchen_lights"})
+        state = ha.get_state("light.kitchen_lights")
+        assert state["state"] == "off"
+        assert state["attributes"]["brightness"] == 0
+
+    def test_toggle(self):
+        ha = HomeAssistantMock()
+        ha.call_service("light", "toggle", {"entity_id": "light.kitchen_lights"})
+        assert ha.get_state("light.kitchen_lights")["state"] == "on"
+        ha.call_service("light", "toggle", {"entity_id": "light.kitchen_lights"})
+        assert ha.get_state("light.kitchen_lights")["state"] == "off"
+
+    def test_set_temperature(self):
+        ha = HomeAssistantMock()
+        ha.call_service("climate", "set_temperature", {
+            "entity_id": "climate.living_room_thermostat",
+            "temperature": 24.0,
+        })
+        state = ha.get_state("climate.living_room_thermostat")
+        assert state["attributes"]["temperature"] == 24.0
+
+    def test_service_log(self):
+        ha = HomeAssistantMock()
+        ha.call_service("light", "turn_on", {"entity_id": "light.kitchen_lights"})
+        ha.call_service("light", "turn_off", {"entity_id": "light.kitchen_lights"})
+        assert len(ha.service_log) == 2
+        assert ha.service_log[0]["service"] == "turn_on"
+        assert ha.service_log[1]["service"] == "turn_off"
+
+    def test_custom_entities(self):
+        entities = [{"entity_id": "switch.fan", "state": "off", "attributes": {"friendly_name": "Fan"}}]
+        ha = HomeAssistantMock(entities=entities)
+        assert len(ha.get_states()) == 1
+        assert ha.get_state("switch.fan")["attributes"]["friendly_name"] == "Fan"
+
+    def test_unknown_entity_service_call(self):
+        ha = HomeAssistantMock()
+        ha.call_service("light", "turn_on", {"entity_id": "light.nonexistent"})
+        assert len(ha.service_log) == 1  # logged but no state change
+
+
+class TestHomeAssistantHTTP:
+    """Test HomeAssistantMock via HTTP (Flask server)."""
+
+    @pytest.fixture
+    def ha_server(self):
+        port = _find_free_port()
+        ha = HomeAssistantMock(port=port)
+        ha.start()
+        time.sleep(0.1)  # allow server to start
+        yield ha, port
+        ha.stop()
+
+    def _request(self, port, path, method="GET", data=None, token="mock-ha-token"):
+        url = f"http://localhost:{port}{path}"
+        body = json.dumps(data).encode() if data else None
+        req = urllib.request.Request(url, data=body, method=method)
+        req.add_header("Authorization", f"Bearer {token}")
+        if data:
+            req.add_header("Content-Type", "application/json")
+        try:
+            with urllib.request.urlopen(req) as resp:
+                return json.loads(resp.read()), resp.status
+        except urllib.error.HTTPError as e:
+            return json.loads(e.read()), e.code
+
+    def test_get_states(self, ha_server):
+        _, port = ha_server
+        data, status = self._request(port, "/api/states")
+        assert status == 200
+        assert len(data) == 3
+
+    def test_get_single_state(self, ha_server):
+        _, port = ha_server
+        data, status = self._request(port, "/api/states/light.kitchen_lights")
+        assert status == 200
+        assert data["entity_id"] == "light.kitchen_lights"
+
+    def test_404_on_missing_entity(self, ha_server):
+        _, port = ha_server
+        data, status = self._request(port, "/api/states/light.nonexistent")
+        assert status == 404
+
+    def test_service_call_via_http(self, ha_server):
+        ha, port = ha_server
+        data, status = self._request(port, "/api/services/light/turn_on",
+                                     method="POST",
+                                     data={"entity_id": "light.kitchen_lights"})
+        assert status == 200
+        assert ha.get_state("light.kitchen_lights")["state"] == "on"
+
+    def test_unauthorized(self, ha_server):
+        _, port = ha_server
+        data, status = self._request(port, "/api/states", token="wrong-token")
+        assert status == 401
+
+
+# ---------------------------------------------------------------------------
+# LLM mock
+# ---------------------------------------------------------------------------
+
+from simulation.layer2.llm_mock import LLMMock
+
+
+class TestLLMMock:
+    """Test LLMMock keyword-to-response and tool-call mapping."""
+
+    def test_default_response(self):
+        llm = LLMMock()
+        assert "not sure" in llm.complete("random gibberish")
+
+    def test_custom_default(self):
+        llm = LLMMock(default_response="Unknown command.")
+        assert llm.complete("anything") == "Unknown command."
+
+    def test_add_rule_match(self):
+        llm = LLMMock()
+        llm.add_rule("weather", "It's sunny and 72 degrees.")
+        assert llm.complete("what's the weather?") == "It's sunny and 72 degrees."
+
+    def test_rule_case_insensitive(self):
+        llm = LLMMock()
+        llm.add_rule("HELLO", "Hi there!")
+        assert llm.complete("hello world") == "Hi there!"
+
+    def test_first_rule_wins(self):
+        llm = LLMMock()
+        llm.add_rule("lights", "First rule.")
+        llm.add_rule("lights", "Second rule.")
+        assert llm.complete("turn on the lights") == "First rule."
+
+    def test_no_match_returns_default(self):
+        llm = LLMMock()
+        llm.add_rule("weather", "Sunny.")
+        assert "not sure" in llm.complete("tell me a joke")
+
+    def test_stream_produces_deltas(self):
+        llm = LLMMock()
+        llm.add_rule("test", "Hello world from LLM.")
+        deltas = list(llm.stream("test prompt"))
+        assert len(deltas) > 1
+        assert "".join(deltas) == "Hello world from LLM."
+
+    def test_tool_call_match(self):
+        llm = LLMMock()
+        llm.add_tool_rule("turn on", tool="homeassistant", args={"action": "turn_on"})
+        result = llm.tool_call("turn on the lights")
+        assert result is not None
+        assert result["tool"] == "homeassistant"
+        assert result["args"]["action"] == "turn_on"
+
+    def test_tool_call_no_match(self):
+        llm = LLMMock()
+        llm.add_tool_rule("turn on", tool="homeassistant", args={})
+        assert llm.tool_call("what's the weather?") is None
+
+    def test_tool_call_returns_copy(self):
+        llm = LLMMock()
+        llm.add_tool_rule("test", tool="t", args={"k": "v"})
+        r1 = llm.tool_call("test")
+        r2 = llm.tool_call("test")
+        assert r1 is not r2  # independent copies
+
+    def test_multiple_tool_rules(self):
+        llm = LLMMock()
+        llm.add_tool_rule("lights on", tool="ha", args={"action": "turn_on"})
+        llm.add_tool_rule("lights off", tool="ha", args={"action": "turn_off"})
+        on = llm.tool_call("lights on please")
+        off = llm.tool_call("lights off please")
+        assert on["args"]["action"] == "turn_on"
+        assert off["args"]["action"] == "turn_off"
+
+
+# ---------------------------------------------------------------------------
+# Memory / RAG mock
+# ---------------------------------------------------------------------------
+
+from simulation.layer2.memory_mock import MemoryMock
+
+
+class TestMemoryMock:
+    """Test MemoryMock SQLite-backed fact store."""
+
+    def test_store_and_count(self):
+        mem = MemoryMock()
+        assert mem.count() == 0
+        mem.store("The sky is blue.")
+        assert mem.count() == 1
+
+    def test_store_returns_id(self):
+        mem = MemoryMock()
+        fact_id = mem.store("Fact one.")
+        assert isinstance(fact_id, str)
+        assert len(fact_id) == 36  # UUID4
+
+    def test_retrieve_by_keyword(self):
+        mem = MemoryMock()
+        mem.store("The kitchen lights are Philips Hue bulbs.")
+        mem.store("The bedroom has blackout curtains.")
+        results = mem.retrieve("kitchen lights")
+        assert len(results) >= 1
+        assert "kitchen" in results[0]["text"].lower()
+        assert results[0]["score"] > 0
+
+    def test_retrieve_returns_score(self):
+        mem = MemoryMock()
+        mem.store("The kitchen lights are smart bulbs.")
+        results = mem.retrieve("kitchen lights")
+        assert "score" in results[0]
+        assert 0 < results[0]["score"] <= 1.0
+
+    def test_retrieve_top_k(self):
+        mem = MemoryMock()
+        for i in range(10):
+            mem.store(f"Fact number {i} about lights.")
+        results = mem.retrieve("lights", top_k=3)
+        assert len(results) == 3
+
+    def test_retrieve_no_match(self):
+        mem = MemoryMock()
+        mem.store("The sky is blue.")
+        results = mem.retrieve("quantum physics")
+        assert len(results) == 0
+
+    def test_retrieve_empty_query(self):
+        mem = MemoryMock()
+        mem.store("Something.")
+        assert mem.retrieve("") == []
+
+    def test_delete(self):
+        mem = MemoryMock()
+        fact_id = mem.store("Temporary fact.")
+        assert mem.count() == 1
+        assert mem.delete(fact_id) is True
+        assert mem.count() == 0
+
+    def test_delete_nonexistent(self):
+        mem = MemoryMock()
+        assert mem.delete("nonexistent-id") is False
+
+    def test_metadata_stored_and_retrieved(self):
+        mem = MemoryMock()
+        mem.store("Kitchen has smart lights.", metadata={"room": "kitchen", "type": "lights"})
+        results = mem.retrieve("kitchen lights")
+        assert "metadata" in results[0]
+        assert results[0]["metadata"]["room"] == "kitchen"
+
+    def test_multiple_stores_independent(self):
+        mem = MemoryMock()
+        id1 = mem.store("Fact one.")
+        id2 = mem.store("Fact two.")
+        assert id1 != id2
+        assert mem.count() == 2


### PR DESCRIPTION
## Summary
Implement all Platform layer HAL (Hardware Abstraction Layer) Abstract Base Classes:

- `HomeAssistantMock(HomeAssistantInterface)` — Flask REST API server with direct HAL access; entity state management (turn_on, turn_off, toggle, set_temperature); bearer token auth; default entities (kitchen lights, bedroom lights, living room thermostat)
- `LLMMock(LLMInterface)` — Keyword-to-response and keyword-to-tool-call mapping with streaming delta support. Works like voice assistant skills (Amazon Alexa / Google Assistant) for deterministic testing without GPU or API keys
- `MemoryMock(MemoryInterface)` — SQLite-backed fact store with keyword overlap scoring; metadata support; in-memory or persistent database

Also defines `simulation/hal/platform.py` interface contracts and extends `docs/guide.md` with Platform layer usage examples including a voice assistant comparison table.

## Type of Change
- [x] New feature
- [x] Documentation
- [ ] Bug fix
- [ ] Refactoring

## Testing
- [x] 38 Platform layer tests — all passing (121 total across all three layers)
- [x] Home Assistant: direct HAL API + HTTP server integration tests
- [x] LLM: keyword rules, tool calls, streaming, case insensitivity
- [x] Memory: store, retrieve, delete, top_k, metadata, keyword scoring

## Checklist
- [x] Tests added (tests/test_layer2.py)
- [x] Documentation updated (docs/guide.md, layer2/__init__.py)
- [x] No breaking changes
- [x] HAL interfaces defined before implementations

**Stacked on**: PR #12 (Network layer)
Closes #10
Tracked by: malcolmhoward/the-oasis-project-meta-repo#38 (onboarding sequence)

---
🤖 Generated with [Claude Code](https://claude.ai/code)